### PR TITLE
[학성] 3 단계 - 점진적인 리펙토링 미션 제출합니다.

### DIFF
--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -12,12 +12,12 @@ import kitchenpos.domain.product.ProductPrice;
 import kitchenpos.dto.menu.MenuProductDto;
 import kitchenpos.dto.menu.MenuRequest;
 import kitchenpos.dto.menu.MenuResponse;
+import kitchenpos.exception.NotFoundProductException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class MenuService {
@@ -54,7 +54,7 @@ public class MenuService {
         final List<MenuProductDto> menuProductDtos = menuRequest.getMenuProducts();
         for (final MenuProductDto menuProductDto : menuProductDtos) {
             final Product product = productRepository.findById(menuProductDto.getProductId())
-                    .orElseThrow(IllegalArgumentException::new);
+                    .orElseThrow(NotFoundProductException::new);
             ProductPrice productPrice = product.getProductPrice();
             sum = sum.add(productPrice.multiply(menuProductDto.getQuantity()));
         }
@@ -62,30 +62,10 @@ public class MenuService {
     }
 
     private void addMenuProductToMenu(MenuRequest menuRequest, Menu menu) {
-        List<Product> products = findAllProductInMenuRequest(menuRequest);
-
-        for (Product product : products) {
-            long quantity = menuRequest.getMenuProducts().stream()
-                    .filter(menuProduct -> menuProduct.equalsProduct(product))
-                    .findAny()
-                    .orElseThrow(IllegalArgumentException::new)
-                    .getQuantity();
-            MenuProduct menuProductToSave = new MenuProduct(menu, product, quantity);
+        for (MenuProductDto menuProduct : menuRequest.getMenuProducts()) {
+            MenuProduct menuProductToSave = new MenuProduct(menu, menuProduct.getProductId(), menuProduct.getQuantity());
             menu.addMenuProduct(menuProductRepository.save(menuProductToSave));
         }
-    }
-
-    private List<Product> findAllProductInMenuRequest(MenuRequest menuRequest) {
-        List<Long> productIds = menuRequest.getMenuProducts().stream()
-                .mapToLong(MenuProductDto::getProductId)
-                .boxed()
-                .collect(Collectors.toList());
-        List<Product> products = productRepository.findAllById(productIds);
-
-        if (products.size() != productIds.size()) {
-            throw new IllegalArgumentException();
-        }
-        return products;
     }
 
     public List<MenuResponse> list() {

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -62,11 +62,7 @@ public class MenuService {
     }
 
     private void addMenuProductToMenu(MenuRequest menuRequest, Menu menu) {
-        List<Long> productIds = menuRequest.getMenuProducts().stream()
-                .mapToLong(MenuProductDto::getProductId)
-                .boxed()
-                .collect(Collectors.toList());
-        List<Product> products = productRepository.findAllById(productIds);
+        List<Product> products = findAllProductInMenuRequest(menuRequest);
 
         for (Product product : products) {
             long quantity = menuRequest.getMenuProducts().stream()
@@ -77,6 +73,19 @@ public class MenuService {
             MenuProduct menuProductToSave = new MenuProduct(menu, product, quantity);
             menu.addMenuProduct(menuProductRepository.save(menuProductToSave));
         }
+    }
+
+    private List<Product> findAllProductInMenuRequest(MenuRequest menuRequest) {
+        List<Long> productIds = menuRequest.getMenuProducts().stream()
+                .mapToLong(MenuProductDto::getProductId)
+                .boxed()
+                .collect(Collectors.toList());
+        List<Product> products = productRepository.findAllById(productIds);
+
+        if (products.size() != productIds.size()) {
+            throw new IllegalArgumentException();
+        }
+        return products;
     }
 
     public List<MenuResponse> list() {

--- a/src/main/java/kitchenpos/application/OrderService.java
+++ b/src/main/java/kitchenpos/application/OrderService.java
@@ -10,6 +10,7 @@ import kitchenpos.domain.order.OrderTable;
 import kitchenpos.dto.order.OrderLineItemDto;
 import kitchenpos.dto.order.OrderRequest;
 import kitchenpos.dto.order.OrderResponse;
+import kitchenpos.exception.NotFoundMenuException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +53,7 @@ public class OrderService {
                 .map(OrderLineItemDto::getMenuId)
                 .collect(Collectors.toList());
         if (menuRepository.countAllByIdIn(menuIds) != menuIds.size()) {
-            throw new IllegalArgumentException();
+            throw new NotFoundMenuException();
         }
         for (OrderLineItemDto orderLineItemDto : orderRequest.getOrderLineItems()) {
             OrderLineItem orderLineItem = new OrderLineItem(savedOrder, orderLineItemDto.getMenuId(), orderLineItemDto.getQuantity());

--- a/src/main/java/kitchenpos/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/application/TableGroupService.java
@@ -34,8 +34,7 @@ public class TableGroupService {
                 .map(orderTableDto -> orderTableRepository.findById(orderTableDto.getId()).orElseThrow(IllegalArgumentException::new))
                 .collect(Collectors.toList());
 
-        TableGroup TableGroupToSave = TableGroup.of(savedOrderTables);
-        final TableGroup savedTableGroup = tableGroupRepository.save(TableGroupToSave);
+        final TableGroup savedTableGroup = tableGroupRepository.save(TableGroup.of(savedOrderTables));
 
         for (final OrderTable savedOrderTable : savedOrderTables) {
             savedOrderTable.tableGrouping(savedTableGroup);

--- a/src/main/java/kitchenpos/dao/MenuRepository.java
+++ b/src/main/java/kitchenpos/dao/MenuRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     @Query("select DISTINCT m from Menu m join fetch m.menuGroup g join fetch m.menuProducts")
     List<Menu> findAllFetch();
+
+    int countAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kitchenpos/dao/ProductRepository.java
+++ b/src/main/java/kitchenpos/dao/ProductRepository.java
@@ -3,5 +3,8 @@ package kitchenpos.dao;
 import kitchenpos.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    int countAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/kitchenpos/domain/menu/MenuProduct.java
+++ b/src/main/java/kitchenpos/domain/menu/MenuProduct.java
@@ -1,7 +1,6 @@
 package kitchenpos.domain.menu;
 
 import kitchenpos.config.BaseEntity;
-import kitchenpos.domain.product.Product;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -18,31 +17,29 @@ public class MenuProduct extends BaseEntity {
     @JoinColumn(name = "menu_id", foreignKey = @ForeignKey(name = "FK_MENU_PRODUCT_MENU"))
     private Menu menu;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id", foreignKey = @ForeignKey(name = "FK_MENU_PRODUCT_PRODUCT"))
-    private Product product;
+    private Long productId;
     private long quantity;
 
     public MenuProduct() {
     }
 
-    public MenuProduct(Long id, Menu menu, Product product, long quantity) {
+    public MenuProduct(Long id, Menu menu, Long productId, long quantity) {
         this.id = id;
         this.menu = menu;
-        this.product = product;
+        this.productId = productId;
         this.quantity = quantity;
     }
 
-    public MenuProduct(Menu menu, Product product, long quantity) {
-        this(null, menu, product, quantity);
+    public MenuProduct(Menu menu, Long productId, long quantity) {
+        this(null, menu, productId, quantity);
     }
 
     public Menu getMenu() {
         return menu;
     }
 
-    public Product getProduct() {
-        return product;
+    public Long getProductId() {
+        return productId;
     }
 
     public long getQuantity() {

--- a/src/main/java/kitchenpos/domain/order/OrderLineItem.java
+++ b/src/main/java/kitchenpos/domain/order/OrderLineItem.java
@@ -1,7 +1,6 @@
 package kitchenpos.domain.order;
 
 import kitchenpos.config.BaseEntity;
-import kitchenpos.domain.menu.Menu;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.Column;
@@ -10,7 +9,6 @@ import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 
 @AttributeOverride(name = "id", column = @Column(name = "order_line_item_id"))
 @Entity
@@ -18,32 +16,29 @@ public class OrderLineItem extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id", foreignKey = @ForeignKey(name = "FK_ORDER_LINE_ITEM_ORDER"))
     private Order order;
-
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "menu_id", foreignKey = @ForeignKey(name = "FK_ORDER_LINE_ITEM_MENU"))
-    private Menu menu;
+    private Long menuId;
     private long quantity;
 
     public OrderLineItem() {
     }
 
-    public OrderLineItem(Long id, Order order, Menu menu, long quantity) {
+    public OrderLineItem(Long id, Order order, Long menuId, long quantity) {
         this.id = id;
         this.order = order;
-        this.menu = menu;
+        this.menuId = menuId;
         this.quantity = quantity;
     }
 
-    public OrderLineItem(Order order, Menu menu, long quantity) {
-        this(null, order, menu, quantity);
+    public OrderLineItem(Order order, Long menuId, long quantity) {
+        this(null, order, menuId, quantity);
     }
 
     public Order getOrder() {
         return order;
     }
 
-    public Menu getMenu() {
-        return menu;
+    public Long getMenuId() {
+        return menuId;
     }
 
     public long getQuantity() {

--- a/src/main/java/kitchenpos/domain/order/TableGroup.java
+++ b/src/main/java/kitchenpos/domain/order/TableGroup.java
@@ -14,21 +14,21 @@ import java.util.List;
 @AttributeOverride(name = "id", column = @Column(name = "table_group_id"))
 @Entity
 public class TableGroup extends BaseEntity {
-    @OneToMany(mappedBy = "tableGroup", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "tableGroup", fetch = FetchType.EAGER)
     private List<OrderTable> orderTables;
     private LocalDateTime createdDate;
 
     public TableGroup() {
     }
 
-    public TableGroup(Long id, List<OrderTable> orderTables, LocalDateTime createdDate) {
+    private TableGroup(Long id, List<OrderTable> orderTables, LocalDateTime createdDate) {
         validateOrderTablesToGrouping(orderTables);
         this.id = id;
         this.orderTables = orderTables;
         this.createdDate = createdDate;
     }
 
-    public TableGroup(List<OrderTable> orderTables, LocalDateTime createdDate) {
+    private TableGroup(List<OrderTable> orderTables, LocalDateTime createdDate) {
         this(null, orderTables, createdDate);
     }
 

--- a/src/main/java/kitchenpos/dto/menu/MenuProductDto.java
+++ b/src/main/java/kitchenpos/dto/menu/MenuProductDto.java
@@ -30,7 +30,7 @@ public class MenuProductDto {
         return new MenuProductDto(
                 menuProduct.getId(),
                 menuProduct.getMenu().getId(),
-                menuProduct.getProduct().getId(),
+                menuProduct.getProductId(),
                 menuProduct.getQuantity()
         );
     }

--- a/src/main/java/kitchenpos/dto/order/OrderLineItemDto.java
+++ b/src/main/java/kitchenpos/dto/order/OrderLineItemDto.java
@@ -29,7 +29,7 @@ public class OrderLineItemDto {
         return new OrderLineItemDto(
                 orderLineItem.getId(),
                 orderLineItem.getOrder().getId(),
-                orderLineItem.getMenu().getId(),
+                orderLineItem.getMenuId(),
                 orderLineItem.getQuantity()
         );
     }

--- a/src/main/java/kitchenpos/exception/NotFoundMenuException.java
+++ b/src/main/java/kitchenpos/exception/NotFoundMenuException.java
@@ -1,0 +1,6 @@
+package kitchenpos.exception;
+
+public class NotFoundMenuException extends RuntimeException {
+    public NotFoundMenuException() {
+    }
+}

--- a/src/main/java/kitchenpos/exception/NotFoundProductException.java
+++ b/src/main/java/kitchenpos/exception/NotFoundProductException.java
@@ -1,0 +1,7 @@
+package kitchenpos.exception;
+
+public class NotFoundProductException extends RuntimeException {
+    public NotFoundProductException() {
+        super();
+    }
+}

--- a/src/main/resources/db/migration/V1__Initialize_project_tables.sql
+++ b/src/main/resources/db/migration/V1__Initialize_project_tables.sql
@@ -68,11 +68,6 @@ alter table menu_product
    references menu;
 
 alter table order_line_item
-   add constraint FK_ORDER_LINE_ITEM_MENU
-   foreign key (menu_id)
-   references menu;
-
-alter table order_line_item
    add constraint FK_ORDER_LINE_ITEM_ORDER
    foreign key (order_id)
    references orders;

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -5,9 +5,14 @@ import kitchenpos.dao.MenuGroupRepository;
 import kitchenpos.dao.MenuProductRepository;
 import kitchenpos.dao.MenuRepository;
 import kitchenpos.dao.ProductRepository;
+import kitchenpos.domain.menu.MenuGroup;
 import kitchenpos.domain.menu.MenuProduct;
+import kitchenpos.domain.product.Product;
+import kitchenpos.domain.product.ProductPrice;
+import kitchenpos.dto.menu.MenuProductDto;
 import kitchenpos.dto.menu.MenuRequest;
 import kitchenpos.dto.menu.MenuResponse;
+import kitchenpos.exception.NotFoundProductException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +21,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,6 +100,31 @@ class MenuServiceTest extends TestFixtureFactory {
 
         assertThatThrownBy(() -> menuService.create(menuRequest))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("메뉴 생성 - 존재하지 않는 product의 id를 전달받은 경우")
+    @Test
+    void createWhenNotFoundProduct() {
+        String menuName = "양념2마리";
+        int menuPrice = 20000;
+        String menuGroupName = "추천메뉴";
+        String productName = "양념";
+        int productPrice = 13000;
+
+        MenuGroup savedMenuGroup = menuGroupRepository.save(new MenuGroup(menuGroupName));
+        Product savedProduct = productRepository.save(new Product(productName, ProductPrice.of(productPrice)));
+        List<MenuProductDto> menuProductDtos = Arrays.asList(
+                new MenuProductDto(savedProduct.getId(), 2),
+                new MenuProductDto(savedProduct.getId() + 1, 3)
+        );
+
+        MenuRequest menuRequest = new MenuRequest(menuName,
+                BigDecimal.valueOf(menuPrice),
+                savedMenuGroup.getId(),
+                menuProductDtos);
+
+        assertThatThrownBy(() -> menuService.create(menuRequest))
+                .isInstanceOf(NotFoundProductException.class);
     }
 
     @DisplayName("메뉴 목록 조회 기능 테스트")

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -11,6 +11,7 @@ import kitchenpos.domain.order.OrderTable;
 import kitchenpos.dto.order.OrderLineItemDto;
 import kitchenpos.dto.order.OrderRequest;
 import kitchenpos.dto.order.OrderResponse;
+import kitchenpos.exception.NotFoundMenuException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -85,7 +86,7 @@ class OrderServiceTest extends TestFixtureFactory {
         OrderRequest orderRequest = new OrderRequest(savedOrderTable.getId(), null, orderLineItemDtos);
 
         assertThatThrownBy(() -> orderService.create(orderRequest))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(NotFoundMenuException.class);
     }
 
     @DisplayName("주문 목록 조회 메서드 테스트")

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -4,6 +4,7 @@ import kitchenpos.application.common.TestFixtureFactory;
 import kitchenpos.dao.MenuRepository;
 import kitchenpos.dao.OrderLineItemRepository;
 import kitchenpos.dao.OrderRepository;
+import kitchenpos.domain.menu.Menu;
 import kitchenpos.domain.order.OrderLineItem;
 import kitchenpos.domain.order.OrderStatus;
 import kitchenpos.domain.order.OrderTable;
@@ -68,8 +69,20 @@ class OrderServiceTest extends TestFixtureFactory {
     @DisplayName("주문 생성 - 주문 요청 시 orderLineItems의 menuId가 존재하지 않는 menu의 아이디일 경우 예외처리")
     @Test
     void createWhenIllegalMenuId() {
-        OrderTable savedOrderTable = makeSavedOrderTable(0, true);
-        OrderRequest orderRequest = new OrderRequest(savedOrderTable.getId(), null, new ArrayList<>());
+        OrderTable savedOrderTable = makeSavedOrderTable(0, false);
+        Menu savedMenu = makeSavedMenu(
+                "양념2마리",
+                20000,
+                "추천메뉴",
+                "양념",
+                11000,
+                2
+        );
+        List<OrderLineItemDto> orderLineItemDtos = new ArrayList<>();
+        orderLineItemDtos.add(new OrderLineItemDto(savedMenu.getId(), 3));
+        orderLineItemDtos.add(new OrderLineItemDto(savedMenu.getId() + 1, 3));
+
+        OrderRequest orderRequest = new OrderRequest(savedOrderTable.getId(), null, orderLineItemDtos);
 
         assertThatThrownBy(() -> orderService.create(orderRequest))
                 .isInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
안녕하세요 홍시! 이번 단계에서는 도메인들의 연관 관계에 대해서 한번 리펙토링을 해보았습니다.
그 과정에서 사실 고민도 많이 되었는데 제가 고민하고 내린 결론에 대해서 정리해서 적어보도록 하겠습니다. 피드백 하실때 참고해주시고 잘못된 부분이 있다면 지적 부탁드립니다.

[리펙토링 전]
<img width="879" alt="스크린샷 2020-11-05 오후 1 44 49" src="https://user-images.githubusercontent.com/46298646/98210240-93749500-1f83-11eb-9442-f726bc86b20a.png">

---
양뱡향 관계를 맺고 있는 도멘인을 중점적으로 리펙토링 해보려고 했고 기본적으로 @OneToMany 연관 관계가 필요한 경우는 @OneToMany 단뱡향으로 할 경우 추가 쿼리문 발생 문제가 있기 때문에 @ManyToOne 양방향으로 유지하는 방향으로 했습니다.

# OrderTable - TableGroup

- TableGrouping을 할 때 OrderTable의 정보(그룹 여부)가 필요하다.
  - 도메인 제약 사항을 공유하기 때문에 객체를 묶는것이 좋다고 판단
 
 => TableGroup의 @OneToMany 유지

```java
@OneToMany(mappedBy = "tableGroup", fetch = FetchType.EAGER)
    private List<OrderTable> orderTables;
```

=> 양방향 유지


# Order - OrderLineItem

- Order가 생성될 때 OrderLineItem도 생성되는 구조이다.
- Order 조회할 때 OrderLineItem도 함께 조회하는 경우가 많을 것이라고 판단됨.

=> 양방향 유지



# OrderLineItem - Menu

- 두 객체를 묶을 필요가 없어 보여 Long타입으로 Id만 가지고 있도록 수정



# Menu - MenuProduct

Order-OrderLineItem과 동일한 이유로 양방향 유지



# MenuProduct - Product

OrderLineItem - Menu 와 동일하게 처리하여 Long타입으로 Id만 가지고 있도록 수정


---
[리펙토링 후]
<img width="625" alt="스크린샷 2020-11-05 오후 4 21 57" src="https://user-images.githubusercontent.com/46298646/98210492-0251ee00-1f84-11eb-8ff3-c35392c8572e.png">
 

