### PR TITLE
[그래] 3단계 - 점진적인 리팩토링 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.flywaydb:flyway-core'
     runtimeOnly 'com.h2database:h2'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -11,7 +11,6 @@ import kitchenpos.dto.MenuCreateRequest;
 import kitchenpos.dto.MenuProductRequest;
 import kitchenpos.exception.InvalidPriceException;
 import kitchenpos.exception.MenuGroupNotExistException;
-import kitchenpos.exception.NullRequestException;
 import kitchenpos.exception.ProductNotExistException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @Service
 public class MenuService {
@@ -65,28 +63,8 @@ public class MenuService {
         Long menuGroupId = menuCreateRequest.getMenuGroupId();
         List<MenuProductRequest> menuProductRequests = menuCreateRequest.getMenuProductRequests();
 
-        validateEmpty(menuCreateRequest);
         validateMenuGroupExistence(menuGroupId);
         validatePriceSum(price, menuProductRequests);
-    }
-
-    private void validateEmpty(MenuCreateRequest menuCreateRequest) {
-        String name = menuCreateRequest.getName();
-        Long price = menuCreateRequest.getPrice();
-        Long menuGroupId = menuCreateRequest.getMenuGroupId();
-        List<MenuProductRequest> menuProductRequests = menuCreateRequest.getMenuProductRequests();
-
-        if (Objects.isNull(name) || Objects.isNull(price) || Objects.isNull(menuGroupId) || menuProductRequests.isEmpty()) {
-            throw new NullRequestException();
-        }
-
-        for (MenuProductRequest menuProductRequest : menuProductRequests) {
-            Long productId = menuProductRequest.getProductId();
-            Long quantity = menuProductRequest.getQuantity();
-            if (Objects.isNull(productId) || Objects.isNull(quantity)) {
-                throw new NullRequestException();
-            }
-        }
     }
 
     private void validateMenuGroupExistence(Long menuGroupId) {

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -50,9 +51,11 @@ public class MenuService {
 
         Menu savedMenu = menuDao.save(new Menu(name, price, menuGroupId));
 
-        menuProductRequests.stream()
-            .map(request -> new MenuProduct(savedMenu.getId(), request.getProductId(), request.getQuantity()))
-            .forEach(menuProductDao::save);
+        List<MenuProduct> menuProducts = new ArrayList<>();
+        for (MenuProductRequest request : menuProductRequests) {
+            menuProducts.add(new MenuProduct(savedMenu.getId(), request.getProductId(), request.getQuantity()));
+        }
+        menuProductDao.saveAll(menuProducts);
 
         return savedMenu;
     }

--- a/src/main/java/kitchenpos/application/OrderService.java
+++ b/src/main/java/kitchenpos/application/OrderService.java
@@ -10,12 +10,14 @@ import kitchenpos.domain.Table;
 import kitchenpos.dto.OrderCreateRequest;
 import kitchenpos.dto.OrderMenuRequest;
 import kitchenpos.dto.OrderStatusChangeRequest;
-import kitchenpos.exception.*;
+import kitchenpos.exception.MenuNotExistException;
+import kitchenpos.exception.OrderNotExistException;
+import kitchenpos.exception.TableEmptyException;
+import kitchenpos.exception.TableNotExistenceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -55,27 +57,8 @@ public class OrderService {
     }
 
     private void validateOrderCreateRequest(OrderCreateRequest orderCreateRequest) {
-        validateEmpty(orderCreateRequest);
         validateMenuExistence(orderCreateRequest.getOrderMenuRequests());
         validateTable(orderCreateRequest.getTableId());
-    }
-
-    private void validateEmpty(OrderCreateRequest orderCreateRequest) {
-        List<OrderMenuRequest> orderMenuRequests = orderCreateRequest.getOrderMenuRequests();
-        Long tableId = orderCreateRequest.getTableId();
-
-        if (orderMenuRequests.isEmpty() || Objects.isNull(tableId)) {
-            throw new NullRequestException();
-        }
-
-        for (OrderMenuRequest orderMenuRequest : orderMenuRequests) {
-            Long menuId = orderMenuRequest.getMenuId();
-            Long quantity = orderMenuRequest.getQuantity();
-
-            if (Objects.isNull(menuId) || Objects.isNull(quantity)) {
-                throw new NullRequestException();
-            }
-        }
     }
 
     private void validateMenuExistence(List<OrderMenuRequest> orderMenuRequests) {

--- a/src/main/java/kitchenpos/application/ProductService.java
+++ b/src/main/java/kitchenpos/application/ProductService.java
@@ -1,16 +1,13 @@
 package kitchenpos.application;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Objects;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import kitchenpos.dao.ProductDao;
 import kitchenpos.domain.Product;
 import kitchenpos.dto.ProductCreateRequest;
-import kitchenpos.exception.NullRequestException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 @Service
 public class ProductService {
@@ -22,20 +19,9 @@ public class ProductService {
 
     @Transactional
     public Product create(final ProductCreateRequest productCreateRequest) {
-        validateProductCreateRequest(productCreateRequest);
-
         String name = productCreateRequest.getName();
         BigDecimal price = new BigDecimal(productCreateRequest.getPrice());
         return productDao.save(new Product(name, price));
-    }
-
-    private void validateProductCreateRequest(ProductCreateRequest productCreateRequest) {
-        String name = productCreateRequest.getName();
-        Long price = productCreateRequest.getPrice();
-
-        if (Objects.isNull(price) || Objects.isNull(name)) {
-            throw new NullRequestException();
-        }
     }
 
     public List<Product> list() {

--- a/src/main/java/kitchenpos/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/application/TableGroupService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -54,12 +53,6 @@ public class TableGroupService {
     private void validateSize(List<Long> tableIds) {
         if (tableIds.size() < MIN_TABLE_NUMBER) {
             throw new NotEnoughTableException();
-        }
-
-        for (Long tableId : tableIds) {
-            if (Objects.isNull(tableId)) {
-                throw new NullRequestException();
-            }
         }
     }
 

--- a/src/main/java/kitchenpos/dao/JdbcTemplateMenuProductDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateMenuProductDao.java
@@ -2,10 +2,7 @@ package kitchenpos.dao;
 
 import kitchenpos.domain.MenuProduct;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.*;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
@@ -36,6 +33,12 @@ public class JdbcTemplateMenuProductDao implements MenuProductDao {
         final SqlParameterSource parameters = new BeanPropertySqlParameterSource(entity);
         final Number key = jdbcInsert.executeAndReturnKey(parameters);
         return select(key.longValue());
+    }
+
+    @Override
+    public void saveAll(List<MenuProduct> menuProducts) {
+        SqlParameterSource[] batch = SqlParameterSourceUtils.createBatch(menuProducts.toArray());
+        jdbcInsert.executeBatch(batch);
     }
 
     @Override

--- a/src/main/java/kitchenpos/dao/MenuProductDao.java
+++ b/src/main/java/kitchenpos/dao/MenuProductDao.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 public interface MenuProductDao {
     MenuProduct save(MenuProduct entity);
 
+    void saveAll(List<MenuProduct> menuProducts);
+
     Optional<MenuProduct> findById(Long id);
 
     List<MenuProduct> findAll();

--- a/src/main/java/kitchenpos/dto/ChangeEmptyRequest.java
+++ b/src/main/java/kitchenpos/dto/ChangeEmptyRequest.java
@@ -1,7 +1,10 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotNull;
+
 public class ChangeEmptyRequest {
 
+    @NotNull
     boolean empty;
 
     public ChangeEmptyRequest() {

--- a/src/main/java/kitchenpos/dto/ChangeNumberOfGuestsRequest.java
+++ b/src/main/java/kitchenpos/dto/ChangeNumberOfGuestsRequest.java
@@ -1,7 +1,10 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotNull;
+
 public class ChangeNumberOfGuestsRequest {
 
+    @NotNull
     int numberOfGuests;
 
     public ChangeNumberOfGuestsRequest() {

--- a/src/main/java/kitchenpos/dto/ExceptionResponse.java
+++ b/src/main/java/kitchenpos/dto/ExceptionResponse.java
@@ -1,0 +1,17 @@
+package kitchenpos.dto;
+
+public class ExceptionResponse {
+
+    private String errorMessage;
+
+    public ExceptionResponse() {
+    }
+
+    public ExceptionResponse(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/kitchenpos/dto/MenuCreateRequest.java
+++ b/src/main/java/kitchenpos/dto/MenuCreateRequest.java
@@ -1,15 +1,21 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 public class MenuCreateRequest {
 
+    @NotNull
     private String name;
 
+    @NotNull
     private Long price;
 
+    @NotNull
     private Long menuGroupId;
 
+    @NotEmpty
     private List<MenuProductRequest> menuProductRequests;
 
     public MenuCreateRequest() {

--- a/src/main/java/kitchenpos/dto/MenuProductRequest.java
+++ b/src/main/java/kitchenpos/dto/MenuProductRequest.java
@@ -1,9 +1,13 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotNull;
+
 public class MenuProductRequest {
 
+    @NotNull
     private Long productId;
 
+    @NotNull
     private Long quantity;
 
     public MenuProductRequest() {

--- a/src/main/java/kitchenpos/dto/OrderCreateRequest.java
+++ b/src/main/java/kitchenpos/dto/OrderCreateRequest.java
@@ -1,11 +1,15 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.List;
 
 public class OrderCreateRequest {
 
+    @NotEmpty
     private List<OrderMenuRequest> orderMenuRequests;
 
+    @NotNull
     private Long tableId;
 
     public OrderCreateRequest() {

--- a/src/main/java/kitchenpos/dto/OrderMenuRequest.java
+++ b/src/main/java/kitchenpos/dto/OrderMenuRequest.java
@@ -1,9 +1,13 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotNull;
+
 public class OrderMenuRequest {
 
+    @NotNull
     private Long menuId;
 
+    @NotNull
     private Long quantity;
 
     public OrderMenuRequest() {

--- a/src/main/java/kitchenpos/dto/OrderStatusChangeRequest.java
+++ b/src/main/java/kitchenpos/dto/OrderStatusChangeRequest.java
@@ -2,8 +2,11 @@ package kitchenpos.dto;
 
 import kitchenpos.domain.OrderStatus;
 
+import javax.validation.constraints.NotNull;
+
 public class OrderStatusChangeRequest {
 
+    @NotNull
     private OrderStatus orderStatus;
 
     public OrderStatusChangeRequest() {

--- a/src/main/java/kitchenpos/dto/ProductCreateRequest.java
+++ b/src/main/java/kitchenpos/dto/ProductCreateRequest.java
@@ -1,9 +1,13 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotNull;
+
 public class ProductCreateRequest {
 
+    @NotNull
     private String name;
 
+    @NotNull
     private Long price;
 
     public ProductCreateRequest() {

--- a/src/main/java/kitchenpos/dto/TableGroupCreateRequest.java
+++ b/src/main/java/kitchenpos/dto/TableGroupCreateRequest.java
@@ -1,9 +1,11 @@
 package kitchenpos.dto;
 
+import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 public class TableGroupCreateRequest {
 
+    @NotEmpty
     List<Long> tableIds;
 
     public TableGroupCreateRequest() {

--- a/src/main/java/kitchenpos/exception/NullRequestException.java
+++ b/src/main/java/kitchenpos/exception/NullRequestException.java
@@ -1,7 +1,0 @@
-package kitchenpos.exception;
-
-public class NullRequestException extends RuntimeException {
-    public NullRequestException() {
-        super("값이 비어있는 요청입니다");
-    }
-}

--- a/src/main/java/kitchenpos/ui/GlobalExceptionHandler.java
+++ b/src/main/java/kitchenpos/ui/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package kitchenpos.ui;
+
+import kitchenpos.dto.ExceptionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> processValidationError(MethodArgumentNotValidException exception) {
+        String errorMessage = Objects.requireNonNull(exception.getBindingResult().getFieldError()).getDefaultMessage();
+        return ResponseEntity.
+            badRequest().
+            body(new ExceptionResponse(errorMessage));
+    }
+}

--- a/src/main/java/kitchenpos/ui/MenuRestController.java
+++ b/src/main/java/kitchenpos/ui/MenuRestController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class MenuRestController {
     }
 
     @PostMapping("/api/menus")
-    public ResponseEntity<Menu> create(@RequestBody final MenuCreateRequest menuCreateRequest) {
+    public ResponseEntity<Menu> create(@RequestBody @Valid final MenuCreateRequest menuCreateRequest) {
         final Menu created = menuService.create(menuCreateRequest);
         final URI uri = URI.create("/api/menus/" + created.getId());
         return ResponseEntity.created(uri)

--- a/src/main/java/kitchenpos/ui/OrderRestController.java
+++ b/src/main/java/kitchenpos/ui/OrderRestController.java
@@ -7,6 +7,7 @@ import kitchenpos.dto.OrderStatusChangeRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -19,7 +20,7 @@ public class OrderRestController {
     }
 
     @PostMapping("/api/orders")
-    public ResponseEntity<Order> create(@RequestBody final OrderCreateRequest orderCreateRequest) {
+    public ResponseEntity<Order> create(@RequestBody @Valid final OrderCreateRequest orderCreateRequest) {
         final Order created = orderService.create(orderCreateRequest);
         final URI uri = URI.create("/api/orders/" + created.getId());
         return ResponseEntity.created(uri)
@@ -36,7 +37,7 @@ public class OrderRestController {
     @PutMapping("/api/orders/{orderId}/order-status")
     public ResponseEntity<Order> changeOrderStatus(
             @PathVariable final Long orderId,
-            @RequestBody final OrderStatusChangeRequest orderStatusChangeRequest
+            @RequestBody @Valid final OrderStatusChangeRequest orderStatusChangeRequest
     ) {
         return ResponseEntity.ok(orderService.changeOrderStatus(orderId, orderStatusChangeRequest));
     }

--- a/src/main/java/kitchenpos/ui/ProductRestController.java
+++ b/src/main/java/kitchenpos/ui/ProductRestController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class ProductRestController {
     }
 
     @PostMapping("/api/products")
-    public ResponseEntity<Product> create(@RequestBody final ProductCreateRequest productCreateRequest) {
+    public ResponseEntity<Product> create(@RequestBody @Valid final ProductCreateRequest productCreateRequest) {
         final Product created = productService.create(productCreateRequest);
         final URI uri = URI.create("/api/products/" + created.getId());
         return ResponseEntity.created(uri)

--- a/src/main/java/kitchenpos/ui/TableGroupRestController.java
+++ b/src/main/java/kitchenpos/ui/TableGroupRestController.java
@@ -6,6 +6,7 @@ import kitchenpos.dto.TableGroupCreateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.net.URI;
 
 @RestController
@@ -17,7 +18,7 @@ public class TableGroupRestController {
     }
 
     @PostMapping("/api/table-groups")
-    public ResponseEntity<TableGroup> create(@RequestBody final TableGroupCreateRequest tableGroupCreateRequest) {
+    public ResponseEntity<TableGroup> create(@RequestBody @Valid final TableGroupCreateRequest tableGroupCreateRequest) {
         final TableGroup created = tableGroupService.create(tableGroupCreateRequest);
         final URI uri = URI.create("/api/table-groups/" + created.getId());
         return ResponseEntity.created(uri)

--- a/src/main/java/kitchenpos/ui/TableRestController.java
+++ b/src/main/java/kitchenpos/ui/TableRestController.java
@@ -1,20 +1,15 @@
 package kitchenpos.ui;
 
-import java.net.URI;
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
-
 import kitchenpos.application.TableService;
 import kitchenpos.domain.Table;
 import kitchenpos.dto.ChangeEmptyRequest;
 import kitchenpos.dto.ChangeNumberOfGuestsRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+import java.util.List;
 
 @RestController
 public class TableRestController {
@@ -41,7 +36,7 @@ public class TableRestController {
     @PutMapping("/api/tables/{tableId}/empty")
     public ResponseEntity<Table> changeEmpty(
             @PathVariable final Long tableId,
-            @RequestBody final ChangeEmptyRequest changeEmptyRequest
+            @RequestBody @Valid final ChangeEmptyRequest changeEmptyRequest
     ) {
         return ResponseEntity.ok()
                 .body(tableService.changeEmpty(tableId, changeEmptyRequest.isEmpty()));
@@ -50,7 +45,7 @@ public class TableRestController {
     @PutMapping("/api/tables/{tableId}/number-of-guests")
     public ResponseEntity<Table> changeNumberOfGuests(
             @PathVariable final Long tableId,
-            @RequestBody final ChangeNumberOfGuestsRequest changeNumberOfGuestsRequest
+            @RequestBody @Valid final ChangeNumberOfGuestsRequest changeNumberOfGuestsRequest
     ) {
         return ResponseEntity.ok()
                 .body(tableService.changeNumberOfGuests(tableId, changeNumberOfGuestsRequest.getNumberOfGuests()));

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -49,15 +48,6 @@ class OrderServiceTest extends TestFixture {
     @BeforeEach
     void setUp() {
         orderService = new OrderService(menuDao, orderDao, orderMenuDao, tableDao);
-    }
-
-    @DisplayName("주문 생성 예외 테스트: 주문이 비었을 때")
-    @Test
-    void createFailByEmptyOrderMenu() {
-        OrderCreateRequest orderCreateRequest = new OrderCreateRequest(new ArrayList<>(), TABLE_ID_1);
-
-        assertThatThrownBy(() -> orderService.create(orderCreateRequest))
-            .isInstanceOf(NullRequestException.class);
     }
 
     @DisplayName("주문 생성 예외 테스트: 중복 메뉴가 있을 때")

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -1,12 +1,10 @@
 package kitchenpos.application;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-
-import java.util.Arrays;
-import java.util.List;
-
+import kitchenpos.dao.ProductDao;
+import kitchenpos.domain.Product;
+import kitchenpos.dto.ProductCreateRequest;
+import kitchenpos.exception.InvalidPriceException;
+import kitchenpos.fixture.TestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,12 +12,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import kitchenpos.dao.ProductDao;
-import kitchenpos.domain.Product;
-import kitchenpos.dto.ProductCreateRequest;
-import kitchenpos.exception.InvalidPriceException;
-import kitchenpos.exception.NullRequestException;
-import kitchenpos.fixture.TestFixture;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest extends TestFixture {
@@ -32,17 +32,6 @@ class ProductServiceTest extends TestFixture {
     @BeforeEach
     void setUp() {
         productService = new ProductService(productDao);
-    }
-
-    @DisplayName("상품 생성 예외 테스트: 비어있는 요청")
-    @Test
-    void createFailByNullValueTest() {
-        ProductCreateRequest negativeProductCreateRequest =
-            new ProductCreateRequest(null, 1L);
-
-        assertThatThrownBy(() -> productService.create(negativeProductCreateRequest))
-            .isInstanceOf(NullRequestException.class)
-            .hasMessage("값이 비어있는 요청입니다");
     }
 
     @DisplayName("상품 생성 예외 테스트: 가격이 음수일때")

--- a/src/test/java/kitchenpos/dao/DaoTest.java
+++ b/src/test/java/kitchenpos/dao/DaoTest.java
@@ -2,7 +2,6 @@ package kitchenpos.dao;
 
 import kitchenpos.domain.Order;
 import kitchenpos.domain.Table;
-import kitchenpos.fixture.TestFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
@@ -10,10 +9,11 @@ import org.springframework.test.context.jdbc.Sql;
 
 import javax.sql.DataSource;
 
-//TODO: 현재 모든 조회 쿼리에 연관 테이블 join이 빠져있다
+import static kitchenpos.fixture.TestFixture.*;
+
 @JdbcTest
 @Sql({"classpath:truncate.sql"})
-public abstract class DaoTest extends TestFixture {
+public abstract class DaoTest {
 
     protected MenuDao menuDao;
     protected MenuGroupDao menuGroupDao;

--- a/src/test/java/kitchenpos/dao/MenuDaoTest.java
+++ b/src/test/java/kitchenpos/dao/MenuDaoTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/dao/MenuGroupDaoTest.java
+++ b/src/test/java/kitchenpos/dao/MenuGroupDaoTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/dao/MenuProductDaoTest.java
+++ b/src/test/java/kitchenpos/dao/MenuProductDaoTest.java
@@ -4,6 +4,7 @@ import kitchenpos.domain.MenuProduct;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,6 +12,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MenuProductDaoTest extends DaoTest {
+
+    @DisplayName("전체저장 테스트")
+    @Test
+    void saveAllTest() {
+        List<MenuProduct> menuProducts = Arrays.asList(MENU_PRODUCT_1, MENU_PRODUCT_2);
+        menuProductDao.saveAll(menuProducts);
+
+        List<MenuProduct> savedMenuProducts = menuProductDao.findAll();
+
+        assertThat(savedMenuProducts).hasSize(4);
+    }
 
     @DisplayName("전체조회 테스트")
     @Test

--- a/src/test/java/kitchenpos/dao/MenuProductDaoTest.java
+++ b/src/test/java/kitchenpos/dao/MenuProductDaoTest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/dao/OrderDaoTest.java
+++ b/src/test/java/kitchenpos/dao/OrderDaoTest.java
@@ -1,17 +1,17 @@
 package kitchenpos.dao;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import kitchenpos.domain.Order;
+import kitchenpos.domain.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import kitchenpos.domain.Order;
-import kitchenpos.domain.OrderStatus;
+import static kitchenpos.fixture.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class OrderDaoTest extends DaoTest {
 

--- a/src/test/java/kitchenpos/dao/OrderMenuDaoTest.java
+++ b/src/test/java/kitchenpos/dao/OrderMenuDaoTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/dao/ProductDaoTest.java
+++ b/src/test/java/kitchenpos/dao/ProductDaoTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/dao/TableDaoTest.java
+++ b/src/test/java/kitchenpos/dao/TableDaoTest.java
@@ -1,16 +1,16 @@
 package kitchenpos.dao;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import kitchenpos.domain.Table;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import kitchenpos.domain.Table;
+import static kitchenpos.fixture.TestFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class TableDaoTest extends DaoTest {
 

--- a/src/test/java/kitchenpos/dao/TableGroupDaoTest.java
+++ b/src/test/java/kitchenpos/dao/TableGroupDaoTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static kitchenpos.fixture.TestFixture.TABLE_GROUP;
+import static kitchenpos.fixture.TestFixture.TABLE_GROUP_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/kitchenpos/ui/MenuRestControllerTest.java
+++ b/src/test/java/kitchenpos/ui/MenuRestControllerTest.java
@@ -1,22 +1,25 @@
 package kitchenpos.ui;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Arrays;
-import java.util.List;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import kitchenpos.application.MenuService;
+import kitchenpos.domain.Menu;
+import kitchenpos.dto.MenuCreateRequest;
+import kitchenpos.dto.MenuProductRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import kitchenpos.application.MenuService;
-import kitchenpos.domain.Menu;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MenuRestController.class)
 class MenuRestControllerTest extends MvcTest {
@@ -27,9 +30,11 @@ class MenuRestControllerTest extends MvcTest {
     @DisplayName("/api/menus로 POST요청 성공 테스트")
     @Test
     void createTest() throws Exception {
+        MenuCreateRequest request = createMenuCreateRequest(MENU_1);
+
         given(menuService.create(any())).willReturn(MENU_1);
 
-        String inputJson = objectMapper.writeValueAsString(MENU_1);
+        String inputJson = objectMapper.writeValueAsString(request);
         MvcResult mvcResult = postAction("/api/menus", inputJson)
             .andExpect(status().isCreated())
             .andExpect(header().string("Location", String.format("/api/menus/%d", MENU_ID_1)))
@@ -56,5 +61,9 @@ class MenuRestControllerTest extends MvcTest {
             () -> assertThat(menusResponse.get(0)).usingRecursiveComparison().isEqualTo(MENU_1),
             () -> assertThat(menusResponse.get(1)).usingRecursiveComparison().isEqualTo(MENU_2)
         );
+    }
+
+    private MenuCreateRequest createMenuCreateRequest(Menu menu) {
+        return new MenuCreateRequest(menu.getName(), menu.getPrice().longValue(), menu.getMenuGroupId(), Arrays.asList(new MenuProductRequest()));
     }
 }

--- a/src/test/java/kitchenpos/ui/OrderRestControllerTest.java
+++ b/src/test/java/kitchenpos/ui/OrderRestControllerTest.java
@@ -28,6 +28,16 @@ class OrderRestControllerTest extends MvcTest {
     @MockBean
     private OrderService orderService;
 
+    @DisplayName("/api/orders로 POST요청 실패 테스트 (비어있는 요청)")
+    @Test
+    void createFailTest() throws Exception {
+        OrderCreateRequest emptyRequest = new OrderCreateRequest();
+
+        String inputJson = objectMapper.writeValueAsString(emptyRequest);
+        postAction("/api/orders", inputJson)
+            .andExpect(status().isBadRequest());
+    }
+
     @DisplayName("/api/orders로 POST요청 성공 테스트")
     @Test
     void createTest() throws Exception {

--- a/src/test/java/kitchenpos/ui/ProductRestControllerTest.java
+++ b/src/test/java/kitchenpos/ui/ProductRestControllerTest.java
@@ -1,28 +1,41 @@
 package kitchenpos.ui;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.Arrays;
-import java.util.List;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import kitchenpos.application.ProductService;
+import kitchenpos.domain.Product;
+import kitchenpos.dto.ProductCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import kitchenpos.application.ProductService;
-import kitchenpos.domain.Product;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductRestController.class)
 class ProductRestControllerTest extends MvcTest {
 
     @MockBean
     private ProductService productService;
+
+    @DisplayName("/api/products로 POST요청 실패 테스트 (비어있는 요청)")
+    @Test
+    void createFailTest() throws Exception {
+        ProductCreateRequest emptyRequest = new ProductCreateRequest();
+
+        String inputJson = objectMapper.writeValueAsString(emptyRequest);
+        postAction("/api/products", inputJson)
+            .andExpect(status().isBadRequest())
+            .andReturn();
+    }
 
     @DisplayName("/api/products로 POST요청 성공 테스트")
     @Test


### PR DESCRIPTION

안녕하세요 후니!

3단계에 해당하는 `양방향을 단방향으로 변경` 부분은 2단계를 할때 같이 진행했습니다!

그리고 주신 피드백에 대해서 적용하지 못한 부분에 대해 질문이 있습니다!!

## 1

> Autowired로 주입받는 것이 어떤가요?

```java
    protected MenuDao menuDao;
	...

	@BeforeEach
	void setUpDatabase() {
	    menuDao = new JdbcTemplateMenuDao(dataSource);
	    menuGroupDao = new JdbcTemplateMenuGroupDao(dataSource);
	    menuProductDao = new JdbcTemplateMenuProductDao(dataSource);
	    ,,,
	}
```

위 코드와 같이 구현 클래스(JdbcTemplateMenuDao)가 코드에 나타나도록 작성하는 게 아니라

```java
    @Autowired
    protected MenuDao menuDao;
```

위 코드처럼 Autowired만 사용해서 코드를 작성하고 싶었지만, 이것저것 시도했음에도 딱히 이렇다할 해결책을 찾지 못하고 있습니다 ㅠㅠ

지금 문득 떠오르는 생각은 xml파일같은 설정파일을 만들어서 MenuDao와 JdbcTemplateMenuDao와의 연관성을 설정하는 방법이 떠오르는데 이와 같은 방법이 올바른 방법일까요?



## 2

> 테스트 데이터에 대해서는 각 테스트 클래스 안에서 생성, 삭제해주세요.
> 컨텍스트에 따라 테스트 데이터를 공유할 수도 있고 해당 클래스를 상속받는 다른 테스트 클래스에서 BeforeEach 등 순서에 대한 제약이 있을 것 같아요.

각 테스트 클래스마다 생성, 삭제를 하게 되면 setUp이 너무 비대해지는 문제 때문에 DaoTest에서 모든 데이터를 구성했었습니다.

예를 들어 OrderMenu에 대한 테스트를 작성할때, 그냥 OrderMenu 인스턴스 하나만 저장하려고 하면 참조 무결성 제약조건 위반 때문에 연관돼있는 Order, Table, TableGroup도 모두 저장을 해야만 했었습니다.

하지만 후니께서 주신 피드백에 공감을 하고 있어요. DaoTest가 지금 많은 테스트에서 상속받고, 이용하고 있기 때문에 문제가 발생할 수 있을 것 같아요.

각각의 테스트에서 생성, 삭제할 수 있으면서도 setUp이 너무 비대해지지 않게 하는 방법이 있을까요? (아님 참조 무결성을 피해갈 수 있는 방법이 있을까요?)