### PR TITLE
[레거시 코드 리팩터링 - 3단계] 배럴(김나은) 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/src/main/java/kitchenpos/application/MenuGroupService.java
+++ b/src/main/java/kitchenpos/application/MenuGroupService.java
@@ -17,13 +17,17 @@ public class MenuGroupService {
 
     @Transactional
     public MenuGroup create(final MenuGroupRequest request) {
-        final MenuGroup menuGroup = MenuGroup.builder()
-                .name(request.getName())
-                .build();
+        final MenuGroup menuGroup = menuGroupWith(request);
         return menuGroupRepository.save(menuGroup);
     }
 
     public List<MenuGroup> list() {
         return menuGroupRepository.findAll();
+    }
+
+    private MenuGroup menuGroupWith(MenuGroupRequest request) {
+        return MenuGroup.builder()
+                .name(request.getName())
+                .build();
     }
 }

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -37,11 +37,7 @@ public class MenuService {
         if (!menuGroupRepository.existsById(request.getMenuGroupId())) {
             throw new IllegalArgumentException();
         }
-        final Menu menu = Menu.builder()
-                .name(request.getName())
-                .price(BigDecimal.valueOf(request.getPrice()))
-                .menuGroupId(request.getMenuGroupId())
-                .build();
+        final Menu menu = menuWith(request);
 
         final Menu savedMenu = menuRepository.save(menu);
         final MenuProducts savedMenuProducts = new MenuProducts(
@@ -55,5 +51,13 @@ public class MenuService {
 
     public List<Menu> list() {
         return menuRepository.findAll();
+    }
+
+    private Menu menuWith(MenuRequest request) {
+        return Menu.builder()
+                .name(request.getName())
+                .price(BigDecimal.valueOf(request.getPrice()))
+                .menuGroupId(request.getMenuGroupId())
+                .build();
     }
 }

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -3,8 +3,10 @@ package kitchenpos.application;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
+import kitchenpos.application.dtos.ProductInformationRequest;
 import kitchenpos.application.dtos.MenuProductRequest;
 import kitchenpos.application.dtos.MenuRequest;
+import kitchenpos.application.dtos.MenuResponse;
 import kitchenpos.domain.Menu;
 import kitchenpos.domain.MenuProduct;
 import kitchenpos.domain.MenuProducts;
@@ -71,5 +73,13 @@ public class MenuService {
                 .price(BigDecimal.valueOf(request.getPrice()))
                 .menuGroupId(request.getMenuGroupId())
                 .build();
+    }
+
+    public MenuResponse update(Long menuId, ProductInformationRequest request) {
+        final Menu menu = menuRepository.findById(menuId)
+                .orElseThrow(IllegalArgumentException::new);
+
+
+        return new MenuResponse(menu);
     }
 }

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -53,7 +53,7 @@ public class MenuService {
     }
 
     public List<Menu> list() {
-        return menuRepository.findAll();
+        return menuRepository.findAllJoinFetch();
     }
 
     private List<MenuProduct> menuProductsWith(List<MenuProductRequest> menuProductsRequest) {

--- a/src/main/java/kitchenpos/application/OrderService.java
+++ b/src/main/java/kitchenpos/application/OrderService.java
@@ -48,7 +48,7 @@ public class OrderService {
 
         final Order savedOrder = orderRepository.save(orderWith(orderTable));
 
-        orderLineItems.updateOrderId(savedOrder.getId());
+        orderLineItems.updateOrderId(savedOrder);
         savedOrder.updateOrderLineItems(orderLineItems);
         orderLineItemRepository.saveAll(orderLineItems.getOrderLineItems());
 

--- a/src/main/java/kitchenpos/application/ProductService.java
+++ b/src/main/java/kitchenpos/application/ProductService.java
@@ -18,15 +18,18 @@ public class ProductService {
 
     @Transactional
     public Product create(final ProductRequest request) {
-        final Product product = Product.builder()
-                .name(request.getName())
-                .price(new Price(request.getPrice()))
-                .build();
-
+        final Product product = productWith(request);
         return productRepository.save(product);
     }
 
     public List<Product> list() {
         return productRepository.findAll();
+    }
+
+    private Product productWith(ProductRequest request) {
+        return Product.builder()
+                .name(request.getName())
+                .price(new Price(request.getPrice()))
+                .build();
     }
 }

--- a/src/main/java/kitchenpos/application/ProductService.java
+++ b/src/main/java/kitchenpos/application/ProductService.java
@@ -1,19 +1,25 @@
 package kitchenpos.application;
 
 import java.util.List;
+import kitchenpos.application.dtos.ProductInformationRequest;
 import kitchenpos.application.dtos.ProductRequest;
-import kitchenpos.repository.ProductRepository;
+import kitchenpos.domain.MenuProductEvent;
 import kitchenpos.domain.Price;
 import kitchenpos.domain.Product;
+import kitchenpos.repository.ProductRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProductService {
     private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public ProductService(final ProductRepository productRepository) {
+    public ProductService(ProductRepository productRepository,
+                          ApplicationEventPublisher eventPublisher) {
         this.productRepository = productRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Transactional
@@ -24,6 +30,16 @@ public class ProductService {
 
     public List<Product> list() {
         return productRepository.findAll();
+    }
+
+    @Transactional
+    public Product update(final Long productId, final ProductInformationRequest request) {
+        final Product product = productRepository.findById(productId)
+                .orElseThrow(IllegalArgumentException::new);
+        product.updatePrice(request.getPrice());
+        eventPublisher.publishEvent(new MenuProductEvent(product.getId(), product.getPrice()));
+        productRepository.save(product);
+        return product;
     }
 
     private Product productWith(ProductRequest request) {

--- a/src/main/java/kitchenpos/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/application/TableGroupService.java
@@ -7,13 +7,13 @@ import java.util.stream.Collectors;
 import kitchenpos.application.dtos.OrderTableRequest;
 import kitchenpos.application.dtos.TableGroupRequest;
 import kitchenpos.application.dtos.TableGroupResponse;
-import kitchenpos.repository.OrderRepository;
-import kitchenpos.repository.OrderTableRepository;
-import kitchenpos.repository.TableGroupRepository;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
 import kitchenpos.domain.OrderTables;
 import kitchenpos.domain.TableGroup;
+import kitchenpos.repository.OrderRepository;
+import kitchenpos.repository.OrderTableRepository;
+import kitchenpos.repository.TableGroupRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,20 +33,10 @@ public class TableGroupService {
 
     @Transactional
     public TableGroupResponse create(final TableGroupRequest request) {
-        final List<OrderTable> orderTablesValue = request.getOrderTables().stream()
-                .map(it -> OrderTable.builder()
-                        .id(it.getId())
-                        .build())
-                .collect(Collectors.toList());
-        final OrderTables orderTables = new OrderTables(orderTablesValue);
-        final List<Long> orderTableIds = request.getOrderTables().stream()
-                .map(OrderTableRequest::getId)
-                .collect(Collectors.toList());
-        final TableGroup tableGroup = TableGroup.builder()
-                .createdDate(LocalDateTime.now())
-                .build();
+        final OrderTables orderTables = new OrderTables(orderTablesWith(request));
+        final List<Long> orderTableIds = orderTableIdsWith(request);
 
-        final TableGroup savedTableGroup = tableGroupRepository.save(tableGroup);
+        final TableGroup savedTableGroup = tableGroupRepository.save(createTableGroup());
         final OrderTables savedOrderTables = new OrderTables(orderTableRepository.findAllByIdIn(orderTableIds));
         savedOrderTables.checkValidity(orderTables);
         savedOrderTables.update(savedTableGroup.getId(), false);
@@ -66,4 +56,25 @@ public class TableGroupService {
         }
         orderTables.update(null, false);
     }
+
+    private TableGroup createTableGroup() {
+        return TableGroup.builder()
+                .createdDate(LocalDateTime.now())
+                .build();
+    }
+
+    private List<Long> orderTableIdsWith(TableGroupRequest request) {
+        return request.getOrderTables().stream()
+                .map(OrderTableRequest::getId)
+                .collect(Collectors.toList());
+    }
+
+    private List<OrderTable> orderTablesWith(TableGroupRequest request) {
+        return request.getOrderTables().stream()
+                .map(it -> OrderTable.builder()
+                        .id(it.getId())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/kitchenpos/application/TableService.java
+++ b/src/main/java/kitchenpos/application/TableService.java
@@ -24,9 +24,7 @@ public class TableService {
 
     @Transactional
     public OrderTable create(final OrderTableRequest request) {
-        final OrderTable orderTable = OrderTable.builder()
-                .id(request.getId())
-                .build();
+        final OrderTable orderTable = orderTableWith(request);
         return orderTableRepository.save(orderTable);
     }
 
@@ -59,4 +57,11 @@ public class TableService {
 
         return orderTableRepository.save(savedOrderTable);
     }
+
+    private OrderTable orderTableWith(OrderTableRequest request) {
+        return OrderTable.builder()
+                .id(request.getId())
+                .build();
+    }
+
 }

--- a/src/main/java/kitchenpos/application/dtos/GuestNumberRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/GuestNumberRequest.java
@@ -1,16 +1,19 @@
 package kitchenpos.application.dtos;
 
 import javax.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 public class GuestNumberRequest {
     @Size(min = 0)
     private int numberOfGuests;
 
+    public GuestNumberRequest() {
+    }
+
     public GuestNumberRequest(int numberOfGuests) {
         this.numberOfGuests = numberOfGuests;
+    }
+
+    public int getNumberOfGuests() {
+        return numberOfGuests;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuGroupRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuGroupRequest.java
@@ -1,14 +1,16 @@
 package kitchenpos.application.dtos;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
 public class MenuGroupRequest {
     private String name;
 
+    public MenuGroupRequest() {
+    }
+
     public MenuGroupRequest(String name) {
         this.name = name;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuGroupResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuGroupResponse.java
@@ -1,9 +1,7 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.MenuGroup;
-import lombok.Getter;
 
-@Getter
 public class MenuGroupResponse {
     private final Long id;
     private final String name;
@@ -11,5 +9,13 @@ public class MenuGroupResponse {
     public MenuGroupResponse(MenuGroup menuGroup) {
         this.id = menuGroup.getId();
         this.name = menuGroup.getName();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuProductRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuProductRequest.java
@@ -1,14 +1,13 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.MenuProduct;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Getter
 public class MenuProductRequest {
     private Long productId;
     private Long quantity;
+
+    public MenuProductRequest() {
+    }
 
     public MenuProductRequest(Long productId, Long quantity) {
         this.productId = productId;
@@ -17,5 +16,13 @@ public class MenuProductRequest {
 
     public MenuProductRequest(MenuProduct menuProduct) {
         this(menuProduct.getProductId(), menuProduct.getQuantity());
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuProductResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuProductResponse.java
@@ -1,9 +1,7 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.MenuProduct;
-import lombok.Getter;
 
-@Getter
 public class MenuProductResponse {
     private final Long productId;
     private final Long quantity;
@@ -11,5 +9,13 @@ public class MenuProductResponse {
     public MenuProductResponse(MenuProduct menuProduct) {
         this.productId = menuProduct.getProductId();
         this.quantity = menuProduct.getQuantity();
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuRequest.java
@@ -3,11 +3,7 @@ package kitchenpos.application.dtos;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Getter
 public class MenuRequest {
     private String name;
     @NotNull
@@ -16,11 +12,30 @@ public class MenuRequest {
     private Long menuGroupId;
     private List<MenuProductRequest> menuProducts;
 
+    public MenuRequest() {
+    }
+
     public MenuRequest(String name, Long price, Long menuGroupId,
                        List<MenuProductRequest> menuProducts) {
         this.name = name;
         this.price = price;
         this.menuGroupId = menuGroupId;
         this.menuProducts = menuProducts;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public Long getMenuGroupId() {
+        return menuGroupId;
+    }
+
+    public List<MenuProductRequest> getMenuProducts() {
+        return menuProducts;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/MenuResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/MenuResponse.java
@@ -3,9 +3,7 @@ package kitchenpos.application.dtos;
 import java.util.List;
 import java.util.stream.Collectors;
 import kitchenpos.domain.Menu;
-import lombok.Getter;
 
-@Getter
 public class MenuResponse {
     private final Long id;
     private final String name;
@@ -21,5 +19,25 @@ public class MenuResponse {
         this.menuProducts = menu.getMenuProducts().stream()
                 .map(MenuProductResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public Long getMenuGroupId() {
+        return MenuGroupId;
+    }
+
+    public List<MenuProductResponse> getMenuProducts() {
+        return menuProducts;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderLineItemRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderLineItemRequest.java
@@ -1,17 +1,24 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.OrderLineItem;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Getter
 public class OrderLineItemRequest {
     private Long menuId;
     private Long quantity;
 
+    public OrderLineItemRequest() {
+    }
+
     public OrderLineItemRequest(OrderLineItem orderLineItem) {
         this.menuId = orderLineItem.getMenuId();
         this.quantity = orderLineItem.getQuantity();
+    }
+
+    public Long getMenuId() {
+        return menuId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderLineItemResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderLineItemResponse.java
@@ -1,9 +1,7 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.OrderLineItem;
-import lombok.Getter;
 
-@Getter
 public class OrderLineItemResponse {
     private final Long id;
     private final Long orderId;
@@ -15,5 +13,21 @@ public class OrderLineItemResponse {
         this.orderId = orderLineItem.getOrderId();
         this.menuId = orderLineItem.getMenuId();
         this.quantity = orderLineItem.getQuantity();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Long getMenuId() {
+        return menuId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderLineItemResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderLineItemResponse.java
@@ -10,7 +10,7 @@ public class OrderLineItemResponse {
 
     public OrderLineItemResponse(OrderLineItem orderLineItem) {
         this.id = orderLineItem.getId();
-        this.orderId = orderLineItem.getOrderId();
+        this.orderId = orderLineItem.getOrder();
         this.menuId = orderLineItem.getMenuId();
         this.quantity = orderLineItem.getQuantity();
     }

--- a/src/main/java/kitchenpos/application/dtos/OrderRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderRequest.java
@@ -1,17 +1,24 @@
 package kitchenpos.application.dtos;
 
 import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@Getter
 public class OrderRequest {
     private Long orderTableId;
     private List<OrderLineItemRequest> orderLineItems;
 
+    public OrderRequest() {
+    }
+
     public OrderRequest(Long orderTableId, List<OrderLineItemRequest> orderLineItems) {
         this.orderTableId = orderTableId;
         this.orderLineItems = orderLineItems;
+    }
+
+    public Long getOrderTableId() {
+        return orderTableId;
+    }
+
+    public List<OrderLineItemRequest> getOrderLineItems() {
+        return orderLineItems;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderResponse.java
@@ -4,9 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import kitchenpos.domain.Order;
-import lombok.Getter;
 
-@Getter
 public class OrderResponse {
     private final Long id;
     private final Long orderTableId;
@@ -22,5 +20,25 @@ public class OrderResponse {
         this.orderLineItems = order.getOrderLineItems().stream()
                 .map(OrderLineItemResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getOrderTableId() {
+        return orderTableId;
+    }
+
+    public String getOrderStatus() {
+        return orderStatus;
+    }
+
+    public LocalDateTime getOrderedTime() {
+        return orderedTime;
+    }
+
+    public List<OrderLineItemResponse> getOrderLineItems() {
+        return orderLineItems;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderStatusRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderStatusRequest.java
@@ -1,14 +1,16 @@
 package kitchenpos.application.dtos;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
 public class OrderStatusRequest {
     private String orderStatus;
 
+    public OrderStatusRequest() {
+    }
+
     public OrderStatusRequest(String orderStatus) {
         this.orderStatus = orderStatus;
+    }
+
+    public String getOrderStatus() {
+        return orderStatus;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderTableRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderTableRequest.java
@@ -1,14 +1,16 @@
 package kitchenpos.application.dtos;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
 public class OrderTableRequest {
     private Long id;
 
+    public OrderTableRequest() {
+    }
+
     public OrderTableRequest(Long id) {
         this.id = id;
+    }
+
+    public Long getId() {
+        return id;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/OrderTableResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/OrderTableResponse.java
@@ -1,9 +1,7 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.OrderTable;
-import lombok.Getter;
 
-@Getter
 public class OrderTableResponse {
     private final Long id;
     private final int numberOfGuests;
@@ -13,5 +11,17 @@ public class OrderTableResponse {
         this.id = orderTable.getId();
         this.numberOfGuests = orderTable.getNumberOfGuests();
         this.empty = orderTable.isEmpty();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getNumberOfGuests() {
+        return numberOfGuests;
+    }
+
+    public boolean isEmpty() {
+        return empty;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/ProductInformationRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/ProductInformationRequest.java
@@ -1,0 +1,22 @@
+package kitchenpos.application.dtos;
+
+public class ProductInformationRequest {
+    private String name;
+    private Long price;
+
+    public ProductInformationRequest() {
+    }
+
+    public ProductInformationRequest(String name, Long price) {
+        this.name = name;
+        this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/kitchenpos/application/dtos/ProductRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/ProductRequest.java
@@ -1,16 +1,22 @@
 package kitchenpos.application.dtos;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@NoArgsConstructor
-@Getter
 public class ProductRequest {
     private String name;
     private Long price;
 
+    public ProductRequest() {
+    }
+
     public ProductRequest(String name, Long price) {
         this.name = name;
         this.price = price;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/ProductResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/ProductResponse.java
@@ -1,9 +1,7 @@
 package kitchenpos.application.dtos;
 
 import kitchenpos.domain.Product;
-import lombok.Getter;
 
-@Getter
 public class ProductResponse {
     private final Long id;
     private final String name;
@@ -13,5 +11,17 @@ public class ProductResponse {
         this.id = product.getId();
         this.name = product.getName();
         this.price = product.getPrice().longValue();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getPrice() {
+        return price;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/ProductResponses.java
+++ b/src/main/java/kitchenpos/application/dtos/ProductResponses.java
@@ -3,9 +3,7 @@ package kitchenpos.application.dtos;
 import java.util.List;
 import java.util.stream.Collectors;
 import kitchenpos.domain.Product;
-import lombok.Getter;
 
-@Getter
 public class ProductResponses {
     private final List<ProductResponse> products;
 
@@ -13,5 +11,9 @@ public class ProductResponses {
         this.products = products.stream()
                 .map(ProductResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public List<ProductResponse> getProducts() {
+        return products;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/TableEmptyRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/TableEmptyRequest.java
@@ -1,14 +1,16 @@
 package kitchenpos.application.dtos;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
 public class TableEmptyRequest {
     private Boolean empty;
 
+    public TableEmptyRequest() {
+    }
+
     public TableEmptyRequest(Boolean empty) {
         this.empty = empty;
+    }
+
+    public Boolean getEmpty() {
+        return empty;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/TableGroupRequest.java
+++ b/src/main/java/kitchenpos/application/dtos/TableGroupRequest.java
@@ -1,15 +1,18 @@
 package kitchenpos.application.dtos;
 
 import java.util.List;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 public class TableGroupRequest {
     private List<OrderTableRequest> orderTables;
 
+    public TableGroupRequest() {
+    }
+
     public TableGroupRequest(List<OrderTableRequest> orderTables) {
         this.orderTables = orderTables;
+    }
+
+    public List<OrderTableRequest> getOrderTables() {
+        return orderTables;
     }
 }

--- a/src/main/java/kitchenpos/application/dtos/TableGroupResponse.java
+++ b/src/main/java/kitchenpos/application/dtos/TableGroupResponse.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import kitchenpos.domain.OrderTable;
 import kitchenpos.domain.TableGroup;
-import lombok.Getter;
 
-@Getter
 public class TableGroupResponse {
     private final Long id;
     private final LocalDateTime createdDate;
@@ -19,5 +17,17 @@ public class TableGroupResponse {
         this.orderTables = orderTables.stream()
                 .map(OrderTableResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public List<OrderTableResponse> getOrderTables() {
+        return orderTables;
     }
 }

--- a/src/main/java/kitchenpos/domain/Menu.java
+++ b/src/main/java/kitchenpos/domain/Menu.java
@@ -46,6 +46,10 @@ public class Menu {
         this.menuProducts = new MenuProducts(menuProducts);
     }
 
+    public void updatePrice(Price price) {
+        this.price = price;
+    }
+
     public static class Builder {
         private Long id;
         private String name;

--- a/src/main/java/kitchenpos/domain/Menu.java
+++ b/src/main/java/kitchenpos/domain/Menu.java
@@ -17,7 +17,7 @@ public class Menu {
     @Column(nullable = false)
     private String name;
     @Column(nullable = false)
-    private BigDecimal price;
+    private Price price;
     @Column(nullable = false)
     private Long menuGroupId;
     @Embedded
@@ -49,7 +49,7 @@ public class Menu {
     public static class Builder {
         private Long id;
         private String name;
-        private BigDecimal price;
+        private Price price;
         private Long menuGroupId;
         private MenuProducts menuProducts;
 
@@ -76,7 +76,7 @@ public class Menu {
         }
 
         public Builder price(BigDecimal price) {
-            this.price = price;
+            this.price = new Price(price);
             return this;
         }
 
@@ -101,7 +101,7 @@ public class Menu {
     }
 
     public BigDecimal getPrice() {
-        return price;
+        return price.getPrice();
     }
 
     public Long getMenuGroupId() {

--- a/src/main/java/kitchenpos/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/domain/MenuProduct.java
@@ -82,10 +82,6 @@ public class MenuProduct {
         return menuId;
     }
 
-    public void setMenuId(final Long menuId) {
-        this.menuId = menuId;
-    }
-
     public Long getProductId() {
         return productId;
     }

--- a/src/main/java/kitchenpos/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/domain/MenuProduct.java
@@ -5,14 +5,17 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class MenuProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false, name = "menu_id")
-    private Long menuId;
+    @ManyToOne
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
     @Column(nullable = false)
     private Long productId;
     @Column(nullable = false)
@@ -23,7 +26,7 @@ public class MenuProduct {
 
     private MenuProduct(Builder builder) {
         this.id = builder.id;
-        this.menuId = builder.menuId;
+        this.menu = builder.menu;
         this.productId = builder.productId;
         this.quantity = builder.quantity;
     }
@@ -32,9 +35,13 @@ public class MenuProduct {
         return new Builder();
     }
 
+    public void updateMenu(Menu menu) {
+        this.menu = menu;
+    }
+
     public static class Builder {
         private Long id;
-        private Long menuId;
+        private Menu menu;
         private Long productId;
         private long quantity;
 
@@ -43,7 +50,7 @@ public class MenuProduct {
 
         public Builder of(MenuProduct menuProduct) {
             this.id = menuProduct.id;
-            this.menuId = menuProduct.menuId;
+            this.menu = menuProduct.menu;
             this.productId = menuProduct.productId;
             this.quantity = menuProduct.quantity;
             return this;
@@ -54,8 +61,8 @@ public class MenuProduct {
             return this;
         }
 
-        public Builder menuId(Long menuId) {
-            this.menuId = menuId;
+        public Builder menu(Menu menu) {
+            this.menu = menu;
             return this;
         }
 
@@ -79,7 +86,7 @@ public class MenuProduct {
     }
 
     public Long getMenuId() {
-        return menuId;
+        return menu.getId();
     }
 
     public Long getProductId() {

--- a/src/main/java/kitchenpos/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/domain/MenuProduct.java
@@ -2,18 +2,20 @@ package kitchenpos.domain;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import org.springframework.data.util.Lazy;
 
 @Entity
 public class MenuProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
     @Column(nullable = false)

--- a/src/main/java/kitchenpos/domain/MenuProductEvent.java
+++ b/src/main/java/kitchenpos/domain/MenuProductEvent.java
@@ -1,0 +1,21 @@
+package kitchenpos.domain;
+
+import java.math.BigDecimal;
+
+public class MenuProductEvent {
+    private final Long productId;
+    private final BigDecimal productPrice;
+
+    public MenuProductEvent(Long productId, BigDecimal productPrice) {
+        this.productId = productId;
+        this.productPrice = productPrice;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public BigDecimal getProductPrice() {
+        return productPrice;
+    }
+}

--- a/src/main/java/kitchenpos/domain/MenuProductEventHandler.java
+++ b/src/main/java/kitchenpos/domain/MenuProductEventHandler.java
@@ -1,0 +1,28 @@
+package kitchenpos.domain;
+
+import kitchenpos.repository.MenuProductRepository;
+import kitchenpos.repository.MenuRepository;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MenuProductEventHandler {
+    private final MenuProductRepository menuProductRepository;
+    private final MenuRepository menuRepository;
+
+    public MenuProductEventHandler(MenuProductRepository menuProductRepository,
+                                   MenuRepository menuRepository) {
+        this.menuProductRepository = menuProductRepository;
+        this.menuRepository = menuRepository;
+    }
+
+    @EventListener
+    public void handle(MenuProductEvent event) {
+        final MenuProduct menuProduct = menuProductRepository.findByProductId(event.getProductId())
+                .orElseThrow(IllegalArgumentException::new);
+        final Menu menu = menuRepository.findById(menuProduct.getMenuId())
+                .orElseThrow(IllegalArgumentException::new);
+        final Price productPrice = new Price(event.getProductPrice());
+        menu.updatePrice(productPrice.multiply(menuProduct.getQuantity()));
+    }
+}

--- a/src/main/java/kitchenpos/domain/MenuProducts.java
+++ b/src/main/java/kitchenpos/domain/MenuProducts.java
@@ -12,8 +12,7 @@ import javax.persistence.OneToMany;
 
 @Embeddable
 public class MenuProducts {
-    @OneToMany(fetch = FetchType.EAGER)
-    @JoinColumn(name = "menu_id")
+    @OneToMany(mappedBy = "menu")
     private List<MenuProduct> menuProducts = new ArrayList<>();
 
     public MenuProducts() {
@@ -29,7 +28,7 @@ public class MenuProducts {
 
     public List<Long> getProductIds() {
         return menuProducts.stream()
-                .map(MenuProduct::getId)
+                .map(MenuProduct::getProductId)
                 .collect(Collectors.toList());
     }
 
@@ -52,5 +51,9 @@ public class MenuProducts {
         if (menuPrice.compareTo(sum) > 0) {
             throw new IllegalArgumentException();
         }
+    }
+
+    public void updateMenu(Menu menu) {
+        menuProducts.forEach(it -> it.updateMenu(menu));
     }
 }

--- a/src/main/java/kitchenpos/domain/MenuProducts.java
+++ b/src/main/java/kitchenpos/domain/MenuProducts.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;

--- a/src/main/java/kitchenpos/domain/Order.java
+++ b/src/main/java/kitchenpos/domain/Order.java
@@ -106,10 +106,6 @@ public class Order {
         return orderTableId;
     }
 
-    public void setOrderTableId(final Long orderTableId) {
-        this.orderTableId = orderTableId;
-    }
-
     public String getOrderStatus() {
         return orderStatus;
     }

--- a/src/main/java/kitchenpos/domain/Order.java
+++ b/src/main/java/kitchenpos/domain/Order.java
@@ -45,6 +45,10 @@ public class Order {
         this.orderLineItems = orderLineItems;
     }
 
+    public void updateOrderLineItems(List<OrderLineItem> orderLineItems) {
+        this.orderLineItems = new OrderLineItems(orderLineItems);
+    }
+
     public static class Builder {
         private Long id;
         private Long orderTableId;

--- a/src/main/java/kitchenpos/domain/OrderDetail.java
+++ b/src/main/java/kitchenpos/domain/OrderDetail.java
@@ -1,0 +1,25 @@
+package kitchenpos.domain;
+
+public class OrderDetail {
+    private Long orderId;
+    private Menu menu;
+    private Integer quantity;
+
+    public OrderDetail(Long orderId, Menu menu, Integer quantity) {
+        this.orderId = orderId;
+        this.menu = menu;
+        this.quantity = quantity;
+    }
+
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public Menu getMenu() {
+        return menu;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+}

--- a/src/main/java/kitchenpos/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/domain/OrderLineItem.java
@@ -5,14 +5,17 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class OrderLineItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(nullable = false, name = "order_id")
-    private Long orderId;
+    @ManyToOne
+    @JoinColumn(name = "order_id")
+    private Order order;
     @Column(nullable = false)
     private Long menuId;
     @Column(nullable = false)
@@ -23,7 +26,7 @@ public class OrderLineItem {
 
     private OrderLineItem(Builder builder) {
         this.id = builder.id;
-        this.orderId = builder.orderId;
+        this.order = builder.order;
         this.menuId = builder.menuId;
         this.quantity = builder.quantity;
     }
@@ -34,7 +37,7 @@ public class OrderLineItem {
 
     public static class Builder {
         private Long id;
-        private Long orderId;
+        private Order order;
         private Long menuId;
         private long quantity;
 
@@ -43,7 +46,7 @@ public class OrderLineItem {
 
         public Builder of(OrderLineItem orderLineItem) {
             this.id = orderLineItem.id;
-            this.orderId = orderLineItem.orderId;
+            this.order = orderLineItem.order;
             this.menuId = orderLineItem.menuId;
             this.quantity = orderLineItem.quantity;
             return this;
@@ -54,8 +57,8 @@ public class OrderLineItem {
             return this;
         }
 
-        public Builder orderId(Long orderId) {
-            this.orderId = orderId;
+        public Builder order(Order order) {
+            this.order = order;
             return this;
         }
 
@@ -79,12 +82,12 @@ public class OrderLineItem {
         return id;
     }
 
-    public Long getOrderId() {
-        return orderId;
+    public Long getOrder() {
+        return order.getId();
     }
 
-    public void updateOrderId(final Long orderId) {
-        this.orderId = orderId;
+    public void updateOrder(final Order order) {
+        this.order = order;
     }
 
     public Long getMenuId() {

--- a/src/main/java/kitchenpos/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/domain/OrderLineItem.java
@@ -83,7 +83,7 @@ public class OrderLineItem {
         return orderId;
     }
 
-    public void setOrderId(final Long orderId) {
+    public void updateOrderId(final Long orderId) {
         this.orderId = orderId;
     }
 

--- a/src/main/java/kitchenpos/domain/OrderLineItems.java
+++ b/src/main/java/kitchenpos/domain/OrderLineItems.java
@@ -4,15 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.Embeddable;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import org.springframework.util.CollectionUtils;
 
 @Embeddable
 public class OrderLineItems {
-    @OneToMany(fetch = FetchType.EAGER)
-    @JoinColumn(name = "order_id")
+    @OneToMany(mappedBy = "order")
     private List<OrderLineItem> orderLineItems;
 
     public OrderLineItems() {
@@ -45,7 +42,7 @@ public class OrderLineItems {
         return new ArrayList<>(orderLineItems);
     }
 
-    public void updateOrderId(Long orderId) {
-        orderLineItems.forEach(it -> it.updateOrderId(orderId));
+    public void updateOrderId(Order order) {
+        orderLineItems.forEach(it -> it.updateOrder(order));
     }
 }

--- a/src/main/java/kitchenpos/domain/OrderLineItems.java
+++ b/src/main/java/kitchenpos/domain/OrderLineItems.java
@@ -46,6 +46,6 @@ public class OrderLineItems {
     }
 
     public void updateOrderId(Long orderId) {
-        orderLineItems.forEach(it -> it.setOrderId(orderId));
+        orderLineItems.forEach(it -> it.updateOrderId(orderId));
     }
 }

--- a/src/main/java/kitchenpos/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/domain/OrderTable.java
@@ -109,10 +109,6 @@ public class OrderTable {
         return tableGroupId;
     }
 
-    public void setTableGroupId(final Long tableGroupId) {
-        this.tableGroupId = tableGroupId;
-    }
-
     public int getNumberOfGuests() {
         return numberOfGuests;
     }

--- a/src/main/java/kitchenpos/domain/Price.java
+++ b/src/main/java/kitchenpos/domain/Price.java
@@ -29,4 +29,8 @@ public class Price {
     public BigDecimal getPrice() {
         return price;
     }
+
+    public Price multiply(Long quantity) {
+        return new Price(this.price.multiply(BigDecimal.valueOf(quantity)));
+    }
 }

--- a/src/main/java/kitchenpos/domain/Price.java
+++ b/src/main/java/kitchenpos/domain/Price.java
@@ -6,7 +6,10 @@ import javax.persistence.Embeddable;
 
 @Embeddable
 public class Price {
-    private final BigDecimal price;
+    private BigDecimal price;
+
+    public Price() {
+    }
 
     public Price(Long price) {
         validate(price);

--- a/src/main/java/kitchenpos/domain/Product.java
+++ b/src/main/java/kitchenpos/domain/Product.java
@@ -29,6 +29,10 @@ public class Product {
         return new Builder();
     }
 
+    public void updatePrice(Long price) {
+        this.price = new Price(price);
+    }
+
     public static class Builder {
         private Long id;
         private String name;

--- a/src/main/java/kitchenpos/domain/TableGroup.java
+++ b/src/main/java/kitchenpos/domain/TableGroup.java
@@ -50,11 +50,6 @@ public class TableGroup {
             return this;
         }
 
-//        public Builder orderTables(List<OrderTable> orderTables) {
-//            this.orderTables = new OrderTables(orderTables);
-//            return this;
-//        }
-
         public TableGroup build() {
             return new TableGroup(this);
         }
@@ -67,16 +62,4 @@ public class TableGroup {
     public LocalDateTime getCreatedDate() {
         return createdDate;
     }
-
-    public void setCreatedDate(final LocalDateTime createdDate) {
-        this.createdDate = createdDate;
-    }
-
-//    public List<OrderTable> getOrderTables() {
-//        return orderTables.getOrderTables();
-//    }
-//
-//    public void setOrderTables(final List<OrderTable> orderTables) {
-//        this.orderTables = new OrderTables(orderTables);
-//    }
 }

--- a/src/main/java/kitchenpos/repository/MenuProductRepository.java
+++ b/src/main/java/kitchenpos/repository/MenuProductRepository.java
@@ -6,6 +6,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
     List<MenuProduct> findAllByMenuId(Long menuId);
-
-    List<MenuProduct> findAllByMenuIdIn(List<Long> menuIds);
 }

--- a/src/main/java/kitchenpos/repository/MenuProductRepository.java
+++ b/src/main/java/kitchenpos/repository/MenuProductRepository.java
@@ -1,9 +1,7 @@
 package kitchenpos.repository;
 
-import java.util.List;
 import kitchenpos.domain.MenuProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
-    List<MenuProduct> findAllByMenuId(Long menuId);
 }

--- a/src/main/java/kitchenpos/repository/MenuProductRepository.java
+++ b/src/main/java/kitchenpos/repository/MenuProductRepository.java
@@ -1,7 +1,9 @@
 package kitchenpos.repository;
 
+import java.util.Optional;
 import kitchenpos.domain.MenuProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
+    Optional<MenuProduct> findByProductId(Long productId);
 }

--- a/src/main/java/kitchenpos/repository/MenuRepository.java
+++ b/src/main/java/kitchenpos/repository/MenuRepository.java
@@ -3,7 +3,11 @@ package kitchenpos.repository;
 import java.util.List;
 import kitchenpos.domain.Menu;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
     Long countByIdIn(List<Long> menuIds);
+
+    @Query("SELECT m FROM Menu m join fetch m.menuProducts.menuProducts")
+    List<Menu> findAllJoinFetch();
 }

--- a/src/main/java/kitchenpos/repository/OrderLineItemRepository.java
+++ b/src/main/java/kitchenpos/repository/OrderLineItemRepository.java
@@ -5,6 +5,5 @@ import kitchenpos.domain.OrderLineItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderLineItemRepository extends JpaRepository<OrderLineItem, Long> {
-    List<OrderLineItem> findAllByOrderId(Long orderId);
 }
 

--- a/src/main/java/kitchenpos/repository/ProductRepository.java
+++ b/src/main/java/kitchenpos/repository/ProductRepository.java
@@ -5,5 +5,5 @@ import kitchenpos.domain.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    List<Product> findAllByIdIn(List<Long> ids);
+    List<Product> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/kitchenpos/ui/MenuRestController.java
+++ b/src/main/java/kitchenpos/ui/MenuRestController.java
@@ -4,12 +4,15 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import kitchenpos.application.MenuService;
+import kitchenpos.application.dtos.ProductInformationRequest;
 import kitchenpos.application.dtos.MenuRequest;
 import kitchenpos.application.dtos.MenuResponse;
 import kitchenpos.domain.Menu;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/kitchenpos/ui/ProductRestController.java
+++ b/src/main/java/kitchenpos/ui/ProductRestController.java
@@ -3,13 +3,16 @@ package kitchenpos.ui;
 import java.net.URI;
 import java.util.List;
 import kitchenpos.application.ProductService;
+import kitchenpos.application.dtos.ProductInformationRequest;
 import kitchenpos.application.dtos.ProductRequest;
 import kitchenpos.application.dtos.ProductResponse;
 import kitchenpos.application.dtos.ProductResponses;
 import kitchenpos.domain.Product;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -34,5 +37,12 @@ public class ProductRestController {
         final List<Product> products = productService.list();
         return ResponseEntity.ok()
                 .body(new ProductResponses(products));
+    }
+
+    @PutMapping("/api/products/{productId}")
+    public ResponseEntity<ProductResponse> update(@PathVariable final Long productId,
+                                                  @RequestBody final ProductInformationRequest request){
+        final Product product = productService.update(productId, request);
+        return ResponseEntity.ok(new ProductResponse(product));
     }
 }

--- a/src/test/java/kitchenpos/TestFixtures.java
+++ b/src/test/java/kitchenpos/TestFixtures.java
@@ -104,7 +104,6 @@ public class TestFixtures {
         return TableGroup.builder()
                 .id(tableGroupId)
                 .createdDate(LocalDateTime.now())
-//                .orderTables(Arrays.asList(createOrderTable(1L, tableGroupId), createOrderTable(2L, tableGroupId)))
                 .build();
     }
 

--- a/src/test/java/kitchenpos/TestFixtures.java
+++ b/src/test/java/kitchenpos/TestFixtures.java
@@ -43,7 +43,7 @@ public class TestFixtures {
     public static MenuProduct createMenuProduct() {
         return MenuProduct.builder()
                 .id(1L)
-                .menuId(1L)
+                .menu(createMenu())
                 .productId(1L)
                 .quantity(1L)
                 .build();

--- a/src/test/java/kitchenpos/TestFixtures.java
+++ b/src/test/java/kitchenpos/TestFixtures.java
@@ -61,7 +61,7 @@ public class TestFixtures {
     public static OrderLineItem createOrderLineItem(Long id) {
         return OrderLineItem.builder()
                 .id(id)
-                .orderId(1L)
+                .order(createOrder())
                 .menuId(1L)
                 .quantity(1L)
                 .build();
@@ -73,7 +73,6 @@ public class TestFixtures {
                 .orderTableId(1L)
                 .orderStatus(OrderStatus.COMPLETION.name())
                 .orderedTime(LocalDateTime.now())
-                .orderLineItems(Arrays.asList(createOrderLineItem(1L), createOrderLineItem(2L)))
                 .build();
     }
 
@@ -86,6 +85,7 @@ public class TestFixtures {
     }
 
     public static OrderRequest createOrderRequest(Order order) {
+        order.updateOrderLineItems(Arrays.asList(createOrderLineItem(1L), createOrderLineItem(2L)));
         final List<OrderLineItemRequest> orderLineItemRequests = order.getOrderLineItems().stream()
                 .map(OrderLineItemRequest::new)
                 .collect(Collectors.toList());

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -109,7 +109,7 @@ class MenuServiceTest {
         final MenuRequest request = new MenuRequest(menuRequest.getName(), menuRequest.getPrice(),
                 menuRequest.getMenuGroupId(), menuProductsRequest);
         when(menuGroupRepository.existsById(any())).thenReturn(true);
-        when(menuProductRepository.findAllByMenuId(any())).thenReturn(Arrays.asList(menuProduct1, menuProduct2));
+        when(menuProductRepository.saveAll(any())).thenReturn(Arrays.asList(menuProduct1, menuProduct2));
         when(productRepository.findAllByIdIn(any())).thenReturn(products);
         when(menuRepository.save(any())).thenReturn(savedMenu1);
 
@@ -154,7 +154,6 @@ class MenuServiceTest {
                 Arrays.asList(new MenuProductRequest(menuProduct1), weirdMenuProductRequest));
         when(menuGroupRepository.existsById(any())).thenReturn(true);
         when(menuRepository.save(any())).thenReturn(savedMenu1);
-        when(menuProductRepository.findAllByMenuId(any())).thenReturn(Arrays.asList(menuProduct1, weirdMenuProduct));
 
         assertThatThrownBy(() -> menuService.create(menuRequest)).isInstanceOf(IllegalArgumentException.class);
     }

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -86,13 +86,13 @@ class MenuServiceTest {
                 .build();
         menuProduct1 = MenuProduct.builder()
                 .id(1L)
-                .menuId(savedMenu1.getId())
+                .menu(savedMenu1)
                 .productId(savedProduct1.getId())
                 .quantity(1L)
                 .build();
         menuProduct2 = MenuProduct.builder()
                 .id(2L)
-                .menuId(savedMenu2.getId())
+                .menu(savedMenu2)
                 .productId(savedProduct2.getId())
                 .quantity(1L)
                 .build();
@@ -109,8 +109,7 @@ class MenuServiceTest {
         final MenuRequest request = new MenuRequest(menuRequest.getName(), menuRequest.getPrice(),
                 menuRequest.getMenuGroupId(), menuProductsRequest);
         when(menuGroupRepository.existsById(any())).thenReturn(true);
-        when(menuProductRepository.saveAll(any())).thenReturn(Arrays.asList(menuProduct1, menuProduct2));
-        when(productRepository.findAllByIdIn(any())).thenReturn(products);
+        when(productRepository.findByIdIn(any())).thenReturn(products);
         when(menuRepository.save(any())).thenReturn(savedMenu1);
 
         final Menu actual = menuService.create(request);
@@ -143,7 +142,7 @@ class MenuServiceTest {
                 .id(3L)
                 .build();
         final MenuProduct weirdMenuProduct = MenuProduct.builder()
-                .menuId(savedMenu1.getId())
+                .menu(savedMenu1)
                 .productId(weirdSavedProduct.getId())
                 .quantity(1L)
                 .build();

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -161,7 +161,7 @@ class MenuServiceTest {
     @Test
     void list() {
         final List<Menu> menus = Arrays.asList(savedMenu1, savedMenu2);
-        when(menuRepository.findAll()).thenReturn(menus);
+        when(menuRepository.findAllJoinFetch()).thenReturn(menus);
 
         final List<Menu> actual = menuService.list();
 

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -111,8 +111,6 @@ class MenuServiceTest {
         when(menuGroupRepository.existsById(any())).thenReturn(true);
         when(menuProductRepository.findAllByMenuId(any())).thenReturn(Arrays.asList(menuProduct1, menuProduct2));
         when(productRepository.findAllByIdIn(any())).thenReturn(products);
-//        when(productRepository.findById(savedProduct1.getId())).thenReturn(Optional.of(savedProduct1));
-//        when(productRepository.findById(savedProduct2.getId())).thenReturn(Optional.of(savedProduct2));
         when(menuRepository.save(any())).thenReturn(savedMenu1);
 
         final Menu actual = menuService.create(request);
@@ -157,8 +155,6 @@ class MenuServiceTest {
         when(menuGroupRepository.existsById(any())).thenReturn(true);
         when(menuRepository.save(any())).thenReturn(savedMenu1);
         when(menuProductRepository.findAllByMenuId(any())).thenReturn(Arrays.asList(menuProduct1, weirdMenuProduct));
-//        when(productRepository.findById(any())).thenReturn(Optional.of(savedProduct1));
-//        when(productRepository.findById(any())).thenReturn(Optional.of(weirdSavedProduct));
 
         assertThatThrownBy(() -> menuService.create(menuRequest)).isInstanceOf(IllegalArgumentException.class);
     }

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -13,14 +13,14 @@ import java.util.stream.Collectors;
 import kitchenpos.application.dtos.OrderLineItemRequest;
 import kitchenpos.application.dtos.OrderRequest;
 import kitchenpos.application.dtos.OrderStatusRequest;
-import kitchenpos.repository.MenuRepository;
-import kitchenpos.repository.OrderLineItemRepository;
-import kitchenpos.repository.OrderRepository;
-import kitchenpos.repository.OrderTableRepository;
 import kitchenpos.domain.Order;
 import kitchenpos.domain.OrderLineItem;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
+import kitchenpos.repository.MenuRepository;
+import kitchenpos.repository.OrderLineItemRepository;
+import kitchenpos.repository.OrderRepository;
+import kitchenpos.repository.OrderTableRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,22 +53,22 @@ class OrderServiceTest {
 
     @BeforeEach
     void setUp() {
+        order = Order.builder()
+                .orderTableId(1L)
+                .orderStatus(OrderStatus.COMPLETION.name())
+                .build();
         final OrderLineItem orderLineItem1 = OrderLineItem.builder()
-                .orderId(1L)
+                .order(order)
                 .menuId(1L)
                 .quantity(1L)
                 .build();
         final OrderLineItem orderLineItem2 = OrderLineItem.builder()
-                .orderId(2L)
+                .order(order)
                 .menuId(2L)
                 .quantity(2L)
                 .build();
         final List<OrderLineItem> orderLineItems = Arrays.asList(orderLineItem1, orderLineItem2);
-        order = Order.builder()
-                .orderTableId(1L)
-                .orderStatus(OrderStatus.COMPLETION.name())
-                .orderLineItems(orderLineItems)
-                .build();
+        order.updateOrderLineItems(orderLineItems);
         orderTable = OrderTable.builder()
                 .id(1L)
                 .empty(false)

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -4,26 +4,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import kitchenpos.application.dtos.ProductInformationRequest;
 import kitchenpos.application.dtos.ProductRequest;
-import kitchenpos.repository.ProductRepository;
+import kitchenpos.domain.MenuProductEvent;
 import kitchenpos.domain.Product;
+import kitchenpos.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @DisplayName("상품")
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private ProductService productService;
@@ -76,5 +86,16 @@ class ProductServiceTest {
 
         final List<Product> actual = productService.list();
         assertThat(actual).containsExactly(product1, product2);
+    }
+
+    @DisplayName("상품의 가격을 변경한다")
+    @Test
+    void update() {
+        final ProductInformationRequest request = new ProductInformationRequest("이름변경", 30000L);
+        when(productRepository.findById(any())).thenReturn(Optional.of(new Product()));
+
+        final Product product = productService.update(1L, request);
+
+        assertThat(product.getPrice()).isEqualTo(BigDecimal.valueOf(request.getPrice()));
     }
 }

--- a/src/test/java/kitchenpos/application/TestJPA.java
+++ b/src/test/java/kitchenpos/application/TestJPA.java
@@ -1,0 +1,51 @@
+package kitchenpos.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import kitchenpos.domain.Menu;
+import kitchenpos.domain.MenuProduct;
+import kitchenpos.repository.MenuProductRepository;
+import kitchenpos.repository.MenuRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@Disabled("테스트용")
+@DataJpaTest
+public class TestJPA {
+
+    @Autowired
+    MenuRepository menuRepository;
+
+    @Autowired
+    MenuProductRepository menuProductRepository;
+
+    @Autowired
+    TestEntityManager testEntityManager;
+
+    @Test
+    void name() {
+        System.out.println("============================");
+
+        Menu menu = menuRepository.findById(1L).get();
+        final List<MenuProduct> all = menuProductRepository.findAll();
+        all.forEach(menuProduct -> menuProduct.updateMenu(menu));
+        menu.updateMenuProducts(all);
+
+        testEntityManager.flush();
+        testEntityManager.clear();
+
+        System.out.println("============================");
+
+        Menu savedMenu = menuRepository.findById(1L).get();
+        final List<Long> menuIds = savedMenu.getMenuProducts().stream()
+                .map(products -> products.getId())
+                .collect(Collectors.toList());
+
+        assertThat(menuIds).hasSize(6);
+    }
+}

--- a/src/test/java/kitchenpos/ui/OrderRestControllerTest.java
+++ b/src/test/java/kitchenpos/ui/OrderRestControllerTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.ui;
 
+import static kitchenpos.TestFixtures.createOrderLineItem;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +58,9 @@ class OrderRestControllerTest {
 
     @Test
     void list() throws Exception {
-        when(orderService.list()).thenReturn(Collections.singletonList(TestFixtures.createOrder()));
+        final Order order = TestFixtures.createOrder();
+        order.updateOrderLineItems(Collections.singletonList(createOrderLineItem(1L)));
+        when(orderService.list()).thenReturn(Collections.singletonList(order));
 
         final MockHttpServletResponse response = mockMvc.perform(get("/api/orders"))
                 .andReturn()
@@ -69,6 +72,7 @@ class OrderRestControllerTest {
     @Test
     void changeOrderStatus() throws Exception {
         final Order order = TestFixtures.createOrder();
+        order.updateOrderLineItems(Collections.singletonList(createOrderLineItem(1L)));
         final String content = objectMapper.writeValueAsString(new OrderStatusRequest(OrderStatus.MEAL.name()));
         when(orderService.changeOrderStatus(any(), any())).thenReturn(order);
 


### PR DESCRIPTION
안녕하세요~! 제리 step3 미션 제출합니다 :)

# 작업내용
- `Menu~MenuProduct`, `Order~OrderLineItem` 는 양방향 연관관계로 수정하였고, 그 외에는 id 관계를 유지하였습니다.
    - 기존 `Menu~MenuProduct`, `Order~OrderLineItem`가 단방향으로 작업했는데, 구현시 문제가 있다는 것을 미션3을 하면서 발견해서 수정하였습니다. 미션3을 다시 하다보니 그전에 잘못 구현되거나 기능하지 않았던 부분들이 보여서 이런 부분을 많이 수정하였네요.ㅎㅎ
- `메뉴의 이름과 가격이 변경되면 주문 항목도 함께 변경된다` 이 요구사항이 어려웠는데, 현재 두 관계 사이에 공유하는 값이 없다고 판단하였습니다. 또한, id로 관계를 가지고 있어 변경되야 하는 사항이 느껴지지 않았습니다. 다만, `Product`의 가격이 변경될 때, `Menu`의 가격이 변경되도록 event 방식을 사용하여 구현하였습니다.

# 기타
- JPA 공부 새롭게 하느라 배우는 점이 많았네요! 혹시 부족한 점이나 의문스러운 점이 있다면 언제든 피드백 주세요! :)
- 이벤트 방식을 사용하는 부분에서 혹시 다른 방향으로 구현이 있다면 공유 부탁드려요.

---

개선할 점 모두 환영입니다!
바쁘실텐데 피드백 미리 감사드릴게요!