### PR TITLE
[레거시 코드 리팩터링 - 2단계] 마코(이규성) 미션 제출합니다.

### DIFF
--- a/src/main/java/kitchenpos/application/MenuGroupService.java
+++ b/src/main/java/kitchenpos/application/MenuGroupService.java
@@ -1,11 +1,13 @@
 package kitchenpos.application;
 
+import kitchenpos.dto.MenuGroupDto;
 import kitchenpos.dao.MenuGroupDao;
 import kitchenpos.domain.MenuGroup;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class MenuGroupService {
@@ -16,11 +18,14 @@ public class MenuGroupService {
     }
 
     @Transactional
-    public MenuGroup create(final MenuGroup menuGroup) {
-        return menuGroupDao.save(menuGroup);
+    public MenuGroupDto create(final MenuGroupDto menuGroupRequest) {
+        MenuGroup savedMenuGroup = menuGroupDao.save(menuGroupRequest.toDomain());
+        return MenuGroupDto.from(savedMenuGroup);
     }
 
-    public List<MenuGroup> list() {
-        return menuGroupDao.findAll();
+    public List<MenuGroupDto> list() {
+        return menuGroupDao.findAll().stream()
+                .map(MenuGroupDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -62,9 +62,7 @@ public class MenuService {
             savedMenuProducts.add(menuProductDao.save(menuProduct));
         }
 
-        Menu saved = new Menu(savedMenu.getId(), savedMenu.getName(), savedMenu.getPrice(), savedMenu.getMenuGroupId(), savedMenuProducts);
-
-        return MenuDto.from(saved);
+        return MenuDto.of(savedMenu, savedMenuProducts);
     }
 
     public List<MenuDto> list() {

--- a/src/main/java/kitchenpos/application/MenuService.java
+++ b/src/main/java/kitchenpos/application/MenuService.java
@@ -7,13 +7,14 @@ import kitchenpos.dao.ProductDao;
 import kitchenpos.domain.Menu;
 import kitchenpos.domain.MenuProduct;
 import kitchenpos.domain.Product;
+import kitchenpos.dto.MenuDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 public class MenuService {
@@ -35,50 +36,44 @@ public class MenuService {
     }
 
     @Transactional
-    public Menu create(final Menu menu) {
-        final BigDecimal price = menu.getPrice();
-
-        if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
+    public MenuDto create(final MenuDto menuDto) {
+        if (!menuGroupDao.existsById(menuDto.getMenuGroupId())) {
             throw new IllegalArgumentException();
         }
 
-        if (!menuGroupDao.existsById(menu.getMenuGroupId())) {
-            throw new IllegalArgumentException();
-        }
-
-        final List<MenuProduct> menuProducts = menu.getMenuProducts();
+        Menu menu = menuDto.toDomain();
 
         BigDecimal sum = BigDecimal.ZERO;
-        for (final MenuProduct menuProduct : menuProducts) {
+        for (final MenuProduct menuProduct : menu.getMenuProducts()) {
             final Product product = productDao.findById(menuProduct.getProductId())
                     .orElseThrow(IllegalArgumentException::new);
             sum = sum.add(product.getPrice().multiply(BigDecimal.valueOf(menuProduct.getQuantity())));
         }
 
-        if (price.compareTo(sum) > 0) {
-            throw new IllegalArgumentException();
-        }
+        menu.validatePrice(sum);
 
         final Menu savedMenu = menuDao.save(menu);
 
         final Long menuId = savedMenu.getId();
         final List<MenuProduct> savedMenuProducts = new ArrayList<>();
-        for (final MenuProduct menuProduct : menuProducts) {
+
+        for (final MenuProduct menuProduct : menu.getMenuProducts()) {
             menuProduct.setMenuId(menuId);
             savedMenuProducts.add(menuProductDao.save(menuProduct));
         }
-        savedMenu.setMenuProducts(savedMenuProducts);
 
-        return savedMenu;
+        Menu saved = new Menu(savedMenu.getId(), savedMenu.getName(), savedMenu.getPrice(), savedMenu.getMenuGroupId(), savedMenuProducts);
+
+        return MenuDto.from(saved);
     }
 
-    public List<Menu> list() {
+    public List<MenuDto> list() {
         final List<Menu> menus = menuDao.findAll();
 
-        for (final Menu menu : menus) {
-            menu.setMenuProducts(menuProductDao.findAllByMenuId(menu.getId()));
-        }
-
-        return menus;
+        return menus.stream()
+                .map(menu -> new Menu(menu.getId(), menu.getName(), menu.getPrice(), menu.getMenuGroupId(),
+                        menuProductDao.findAllByMenuId(menu.getId())))
+                .map(MenuDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kitchenpos/application/OrderService.java
+++ b/src/main/java/kitchenpos/application/OrderService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -88,12 +87,8 @@ public class OrderService {
         final Order savedOrder = orderDao.findById(orderId)
                 .orElseThrow(IllegalArgumentException::new);
 
-        if (Objects.equals(OrderStatus.COMPLETION.name(), savedOrder.getOrderStatus())) {
-            throw new IllegalArgumentException();
-        }
-
         final OrderStatus orderStatus = OrderStatus.valueOf(order.getOrderStatus());
-        savedOrder.changeStatus(orderStatus.name());
+        savedOrder.changeStatus(orderStatus);
 
         orderDao.save(savedOrder);
 

--- a/src/main/java/kitchenpos/application/OrderService.java
+++ b/src/main/java/kitchenpos/application/OrderService.java
@@ -8,9 +8,9 @@ import kitchenpos.domain.Order;
 import kitchenpos.domain.OrderLineItem;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
+import kitchenpos.dto.OrderDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -38,12 +38,8 @@ public class OrderService {
     }
 
     @Transactional
-    public Order create(final Order order) {
-        final List<OrderLineItem> orderLineItems = order.getOrderLineItems();
-
-        if (CollectionUtils.isEmpty(orderLineItems)) {
-            throw new IllegalArgumentException();
-        }
+    public OrderDto create(final OrderDto orderDto) {
+        final List<OrderLineItem> orderLineItems = orderDto.getOrderLineItems();
 
         final List<Long> menuIds = orderLineItems.stream()
                 .map(OrderLineItem::getMenuId)
@@ -53,18 +49,14 @@ public class OrderService {
             throw new IllegalArgumentException();
         }
 
-        order.setId(null);
-
-        final OrderTable orderTable = orderTableDao.findById(order.getOrderTableId())
+        final OrderTable orderTable = orderTableDao.findById(orderDto.getOrderTableId())
                 .orElseThrow(IllegalArgumentException::new);
 
         if (orderTable.isEmpty()) {
             throw new IllegalArgumentException();
         }
 
-        order.setOrderTableId(orderTable.getId());
-        order.setOrderStatus(OrderStatus.COOKING.name());
-        order.setOrderedTime(LocalDateTime.now());
+        Order order = new Order(orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
 
         final Order savedOrder = orderDao.save(order);
 
@@ -74,23 +66,25 @@ public class OrderService {
             orderLineItem.setOrderId(orderId);
             savedOrderLineItems.add(orderLineItemDao.save(orderLineItem));
         }
-        savedOrder.setOrderLineItems(savedOrderLineItems);
 
-        return savedOrder;
+        Order saved = new Order(order.getId(), order.getOrderTableId(), order.getOrderStatus(), order.getOrderedTime(), savedOrderLineItems);
+
+        return OrderDto.from(saved);
     }
 
-    public List<Order> list() {
+    public List<OrderDto> list() {
         final List<Order> orders = orderDao.findAll();
 
-        for (final Order order : orders) {
-            order.setOrderLineItems(orderLineItemDao.findAllByOrderId(order.getId()));
-        }
-
-        return orders;
+        return orders.stream()
+                .map(order -> new Order(order.getId(), order.getOrderTableId(), order.getOrderStatus(),
+                        order.getOrderedTime(),
+                        orderLineItemDao.findAllByOrderId(order.getId())))
+                .map(OrderDto::from)
+                .collect(Collectors.toList());
     }
 
     @Transactional
-    public Order changeOrderStatus(final Long orderId, final Order order) {
+    public OrderDto changeOrderStatus(final Long orderId, final OrderDto order) {
         final Order savedOrder = orderDao.findById(orderId)
                 .orElseThrow(IllegalArgumentException::new);
 
@@ -99,12 +93,13 @@ public class OrderService {
         }
 
         final OrderStatus orderStatus = OrderStatus.valueOf(order.getOrderStatus());
-        savedOrder.setOrderStatus(orderStatus.name());
+        savedOrder.changeStatus(orderStatus.name());
 
         orderDao.save(savedOrder);
 
-        savedOrder.setOrderLineItems(orderLineItemDao.findAllByOrderId(orderId));
+        List<OrderLineItem> orderLineItems = orderLineItemDao.findAllByOrderId(orderId);
+        Order saved = new Order(savedOrder.getId(), savedOrder.getOrderStatus(), savedOrder.getOrderedTime(), orderLineItems);
 
-        return savedOrder;
+        return OrderDto.from(saved);
     }
 }

--- a/src/main/java/kitchenpos/application/ProductService.java
+++ b/src/main/java/kitchenpos/application/ProductService.java
@@ -2,12 +2,12 @@ package kitchenpos.application;
 
 import kitchenpos.dao.ProductDao;
 import kitchenpos.domain.Product;
+import kitchenpos.dto.ProductDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.List;
-import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 public class ProductService {
@@ -18,17 +18,14 @@ public class ProductService {
     }
 
     @Transactional
-    public Product create(final Product product) {
-        final BigDecimal price = product.getPrice();
-
-        if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
-            throw new IllegalArgumentException();
-        }
-
-        return productDao.save(product);
+    public ProductDto create(final ProductDto productDto) {
+        Product product = productDao.save(productDto.toDomain());
+        return ProductDto.from(product);
     }
 
-    public List<Product> list() {
-        return productDao.findAll();
+    public List<ProductDto> list() {
+        return productDao.findAll().stream()
+                .map(ProductDto::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/kitchenpos/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/application/TableGroupService.java
@@ -54,8 +54,7 @@ public class TableGroupService {
 
         final Long tableGroupId = savedTableGroup.getId();
         for (final OrderTable savedOrderTable : savedOrderTables) {
-            savedOrderTable.setTableGroupId(tableGroupId);
-            savedOrderTable.setEmpty(false);
+            savedOrderTable.group(tableGroupId);
             orderTableDao.save(savedOrderTable);
         }
         TableGroup saved = new TableGroup(savedTableGroup.getId(), LocalDateTime.now(), orderTables);
@@ -77,8 +76,7 @@ public class TableGroupService {
         }
 
         for (final OrderTable orderTable : orderTables) {
-            orderTable.setTableGroupId(null);
-            orderTable.setEmpty(false);
+            orderTable.group(null);
             orderTableDao.save(orderTable);
         }
     }

--- a/src/main/java/kitchenpos/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/application/TableGroupService.java
@@ -6,9 +6,9 @@ import kitchenpos.dao.TableGroupDao;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
 import kitchenpos.domain.TableGroup;
+import kitchenpos.dto.TableGroupDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.CollectionUtils;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -29,12 +29,8 @@ public class TableGroupService {
     }
 
     @Transactional
-    public TableGroup create(final TableGroup tableGroup) {
-        final List<OrderTable> orderTables = tableGroup.getOrderTables();
-
-        if (CollectionUtils.isEmpty(orderTables) || orderTables.size() < 2) {
-            throw new IllegalArgumentException();
-        }
+    public TableGroupDto create(final TableGroupDto tableGroupDto) {
+        final List<OrderTable> orderTables = tableGroupDto.getOrderTables();
 
         final List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)
@@ -52,7 +48,7 @@ public class TableGroupService {
             }
         }
 
-        tableGroup.setCreatedDate(LocalDateTime.now());
+        TableGroup tableGroup = new TableGroup(LocalDateTime.now(), orderTables);
 
         final TableGroup savedTableGroup = tableGroupDao.save(tableGroup);
 
@@ -62,9 +58,9 @@ public class TableGroupService {
             savedOrderTable.setEmpty(false);
             orderTableDao.save(savedOrderTable);
         }
-        savedTableGroup.setOrderTables(savedOrderTables);
+        TableGroup saved = new TableGroup(savedTableGroup.getId(), LocalDateTime.now(), orderTables);
 
-        return savedTableGroup;
+        return TableGroupDto.from(saved);
     }
 
     @Transactional

--- a/src/main/java/kitchenpos/dao/JdbcTemplateMenuDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateMenuDao.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -69,11 +70,10 @@ public class JdbcTemplateMenuDao implements MenuDao {
     }
 
     private Menu toEntity(final ResultSet resultSet) throws SQLException {
-        final Menu entity = new Menu();
-        entity.setId(resultSet.getLong("id"));
-        entity.setName(resultSet.getString("name"));
-        entity.setPrice(resultSet.getBigDecimal("price"));
-        entity.setMenuGroupId(resultSet.getLong("menu_group_id"));
-        return entity;
+        Long id = resultSet.getLong("id");
+        String name = resultSet.getString("name");
+        BigDecimal price = resultSet.getBigDecimal("price");
+        Long menuGroupId = resultSet.getLong("menu_group_id");
+        return new Menu(id, name, price, menuGroupId);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateMenuGroupDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateMenuGroupDao.java
@@ -69,9 +69,8 @@ public class JdbcTemplateMenuGroupDao implements MenuGroupDao {
     }
 
     private MenuGroup toEntity(final ResultSet resultSet) throws SQLException {
-        final MenuGroup entity = new MenuGroup();
-        entity.setId(resultSet.getLong("id"));
-        entity.setName(resultSet.getString("name"));
-        return entity;
+        Long id = resultSet.getLong("id");
+        String name = resultSet.getString("name");
+        return new MenuGroup(id, name);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateMenuProductDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateMenuProductDao.java
@@ -69,11 +69,10 @@ public class JdbcTemplateMenuProductDao implements MenuProductDao {
     }
 
     private MenuProduct toEntity(final ResultSet resultSet) throws SQLException {
-        final MenuProduct entity = new MenuProduct();
-        entity.setSeq(resultSet.getLong(KEY_COLUMN_NAME));
-        entity.setMenuId(resultSet.getLong("menu_id"));
-        entity.setProductId(resultSet.getLong("product_id"));
-        entity.setQuantity(resultSet.getLong("quantity"));
-        return entity;
+        Long seq = resultSet.getLong(KEY_COLUMN_NAME);
+        Long menuId = resultSet.getLong("menu_id");
+        Long productId = resultSet.getLong("product_id");
+        Long quantity = resultSet.getLong("quantity");
+        return new MenuProduct(seq, menuId, productId, quantity);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateOrderDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateOrderDao.java
@@ -95,11 +95,10 @@ public class JdbcTemplateOrderDao implements OrderDao {
     }
 
     private Order toEntity(final ResultSet resultSet) throws SQLException {
-        final Order entity = new Order();
-        entity.setId(resultSet.getLong(KEY_COLUMN_NAME));
-        entity.setOrderTableId(resultSet.getLong("order_table_id"));
-        entity.setOrderStatus(resultSet.getString("order_status"));
-        entity.setOrderedTime(resultSet.getObject("ordered_time", LocalDateTime.class));
-        return entity;
+        Long id = resultSet.getLong(KEY_COLUMN_NAME);
+        Long orderTableId = resultSet.getLong("order_table_id");
+        String orderStatus = resultSet.getString("order_status");
+        LocalDateTime orderedTime = resultSet.getObject("ordered_time", LocalDateTime.class);
+        return new Order(id, orderTableId, orderStatus, orderedTime);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateOrderTableDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateOrderTableDao.java
@@ -94,11 +94,10 @@ public class JdbcTemplateOrderTableDao implements OrderTableDao {
     }
 
     private OrderTable toEntity(final ResultSet resultSet) throws SQLException {
-        final OrderTable entity = new OrderTable();
-        entity.setId(resultSet.getLong(KEY_COLUMN_NAME));
-        entity.setTableGroupId(resultSet.getObject("table_group_id", Long.class));
-        entity.setNumberOfGuests(resultSet.getInt("number_of_guests"));
-        entity.setEmpty(resultSet.getBoolean("empty"));
-        return entity;
+        Long id = resultSet.getLong(KEY_COLUMN_NAME);
+        Long tableGroupId = resultSet.getObject("table_group_id", Long.class);
+        int numberOfGuests = resultSet.getInt("number_of_guests");
+        boolean isEmpty = resultSet.getBoolean("empty");
+        return new OrderTable(id, tableGroupId, numberOfGuests, isEmpty);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateProductDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateProductDao.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -61,10 +62,9 @@ public class JdbcTemplateProductDao implements ProductDao {
     }
 
     private Product toEntity(final ResultSet resultSet) throws SQLException {
-        final Product entity = new Product();
-        entity.setId(resultSet.getLong(KEY_COLUMN_NAME));
-        entity.setName(resultSet.getString("name"));
-        entity.setPrice(resultSet.getBigDecimal("price"));
-        return entity;
+        Long id = resultSet.getLong(KEY_COLUMN_NAME);
+        String name = resultSet.getString("name");
+        BigDecimal price = resultSet.getBigDecimal("price");
+        return new Product(id, name, price);
     }
 }

--- a/src/main/java/kitchenpos/dao/JdbcTemplateTableGroupDao.java
+++ b/src/main/java/kitchenpos/dao/JdbcTemplateTableGroupDao.java
@@ -62,9 +62,8 @@ public class JdbcTemplateTableGroupDao implements TableGroupDao {
     }
 
     private TableGroup toEntity(final ResultSet resultSet) throws SQLException {
-        final TableGroup entity = new TableGroup();
-        entity.setId(resultSet.getLong(KEY_COLUMN_NAME));
-        entity.setCreatedDate(resultSet.getObject("created_date", LocalDateTime.class));
-        return entity;
+        Long id = resultSet.getLong(KEY_COLUMN_NAME);
+        LocalDateTime createdDate = resultSet.getObject("created_date", LocalDateTime.class);
+        return new TableGroup(id, createdDate);
     }
 }

--- a/src/main/java/kitchenpos/domain/MenuGroup.java
+++ b/src/main/java/kitchenpos/domain/MenuGroup.java
@@ -4,19 +4,20 @@ public class MenuGroup {
     private Long id;
     private String name;
 
+    public MenuGroup(String name) {
+        this(null, name);
+    }
+
+    public MenuGroup(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }
 
-    public void setId(final Long id) {
-        this.id = id;
-    }
-
     public String getName() {
         return name;
-    }
-
-    public void setName(final String name) {
-        this.name = name;
     }
 }

--- a/src/main/java/kitchenpos/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/domain/MenuProduct.java
@@ -6,35 +6,30 @@ public class MenuProduct {
     private Long productId;
     private long quantity;
 
-    public Long getSeq() {
-        return seq;
+    public MenuProduct(Long seq, Long menuId, Long productId, long quantity) {
+        this.seq = seq;
+        this.menuId = menuId;
+        this.productId = productId;
+        this.quantity = quantity;
     }
 
-    public void setSeq(final Long seq) {
-        this.seq = seq;
+    public void setMenuId(Long menuId) {
+        this.menuId = menuId;
+    }
+
+    public Long getSeq() {
+        return seq;
     }
 
     public Long getMenuId() {
         return menuId;
     }
 
-    public void setMenuId(final Long menuId) {
-        this.menuId = menuId;
-    }
-
     public Long getProductId() {
         return productId;
     }
 
-    public void setProductId(final Long productId) {
-        this.productId = productId;
-    }
-
     public long getQuantity() {
         return quantity;
-    }
-
-    public void setQuantity(final long quantity) {
-        this.quantity = quantity;
     }
 }

--- a/src/main/java/kitchenpos/domain/Order.java
+++ b/src/main/java/kitchenpos/domain/Order.java
@@ -2,6 +2,7 @@ package kitchenpos.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 public class Order {
     private Long id;
@@ -26,8 +27,15 @@ public class Order {
         this.orderLineItems = orderLineItems;
     }
 
-    public void changeStatus(String orderStatus) {
-        this.orderStatus = orderStatus;
+    public void changeStatus(OrderStatus orderStatus) {
+        validateStatus(orderStatus);
+        this.orderStatus = orderStatus.name();
+    }
+
+    private void validateStatus(OrderStatus orderStatus) {
+        if (Objects.equals(orderStatus.name(), OrderStatus.COMPLETION.name())) {
+            throw new IllegalArgumentException();
+        }
     }
 
     public Long getId() {

--- a/src/main/java/kitchenpos/domain/Product.java
+++ b/src/main/java/kitchenpos/domain/Product.java
@@ -1,33 +1,35 @@
 package kitchenpos.domain;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 public class Product {
     private Long id;
     private String name;
     private BigDecimal price;
 
-    public Long getId() {
-        return id;
+    public Product(Long id, String name, BigDecimal price) {
+        validate(price);
+        this.id = id;
+        this.name = name;
+        this.price = price;
     }
 
-    public void setId(final Long id) {
-        this.id = id;
+    private void validate(BigDecimal price) {
+        if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getName() {
         return name;
     }
 
-    public void setName(final String name) {
-        this.name = name;
-    }
-
     public BigDecimal getPrice() {
         return price;
-    }
-
-    public void setPrice(final BigDecimal price) {
-        this.price = price;
     }
 }

--- a/src/main/java/kitchenpos/domain/TableGroup.java
+++ b/src/main/java/kitchenpos/domain/TableGroup.java
@@ -1,5 +1,7 @@
 package kitchenpos.domain;
 
+import org.springframework.util.CollectionUtils;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -8,27 +10,36 @@ public class TableGroup {
     private LocalDateTime createdDate;
     private List<OrderTable> orderTables;
 
-    public Long getId() {
-        return id;
+    public TableGroup(Long id, LocalDateTime createdDate) {
+        this(id, createdDate, null);
     }
 
-    public void setId(final Long id) {
+    public TableGroup(LocalDateTime createdDate, List<OrderTable> orderTables) {
+        this(null, createdDate, orderTables);
+    }
+
+    public TableGroup(Long id, LocalDateTime createdDate, List<OrderTable> orderTables) {
+        validate(orderTables);
         this.id = id;
+        this.createdDate = createdDate;
+        this.orderTables = orderTables;
+    }
+
+    private void validate(List<OrderTable> orderTables) {
+        if (CollectionUtils.isEmpty(orderTables) || orderTables.size() < 2) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public LocalDateTime getCreatedDate() {
         return createdDate;
     }
 
-    public void setCreatedDate(final LocalDateTime createdDate) {
-        this.createdDate = createdDate;
-    }
-
     public List<OrderTable> getOrderTables() {
         return orderTables;
-    }
-
-    public void setOrderTables(final List<OrderTable> orderTables) {
-        this.orderTables = orderTables;
     }
 }

--- a/src/main/java/kitchenpos/dto/MenuDto.java
+++ b/src/main/java/kitchenpos/dto/MenuDto.java
@@ -18,6 +18,10 @@ public class MenuDto {
         return new MenuDto(menu.getId(), menu.getName(), menu.getPrice(), menu.getMenuGroupId(), menu.getMenuProducts());
     }
 
+    public static MenuDto of(Menu menu, List<MenuProduct> menuProducts) {
+        return new MenuDto(menu.getId(), menu.getName(), menu.getPrice(), menu.getMenuGroupId(), menuProducts);
+    }
+
     public MenuDto(Long id, String name, BigDecimal price, Long menuGroupId, List<MenuProduct> menuProducts) {
         this.id = id;
         this.name = name;

--- a/src/main/java/kitchenpos/dto/MenuDto.java
+++ b/src/main/java/kitchenpos/dto/MenuDto.java
@@ -1,22 +1,24 @@
-package kitchenpos.domain;
+package kitchenpos.dto;
+
+import kitchenpos.domain.Menu;
+import kitchenpos.domain.MenuProduct;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Objects;
 
-public class Menu {
+public class MenuDto {
+
     private Long id;
     private String name;
     private BigDecimal price;
     private Long menuGroupId;
     private List<MenuProduct> menuProducts;
 
-    public Menu(Long id, String name, BigDecimal price, Long menuGroupId) {
-        this(id, name, price, menuGroupId, null);
+    public static MenuDto from(Menu menu) {
+        return new MenuDto(menu.getId(), menu.getName(), menu.getPrice(), menu.getMenuGroupId(), menu.getMenuProducts());
     }
 
-    public Menu(Long id, String name, BigDecimal price, Long menuGroupId, List<MenuProduct> menuProducts) {
-        validate(price);
+    public MenuDto(Long id, String name, BigDecimal price, Long menuGroupId, List<MenuProduct> menuProducts) {
         this.id = id;
         this.name = name;
         this.price = price;
@@ -24,16 +26,8 @@ public class Menu {
         this.menuProducts = menuProducts;
     }
 
-    private void validate(BigDecimal price) {
-        if (Objects.isNull(price) || price.compareTo(BigDecimal.ZERO) < 0) {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    public void validatePrice(BigDecimal sum) {
-        if (price.compareTo(sum) > 0) {
-            throw new IllegalArgumentException();
-        }
+    public Menu toDomain() {
+        return new Menu(id, name, price, menuGroupId, menuProducts);
     }
 
     public Long getId() {

--- a/src/main/java/kitchenpos/dto/MenuGroupDto.java
+++ b/src/main/java/kitchenpos/dto/MenuGroupDto.java
@@ -1,0 +1,33 @@
+package kitchenpos.dto;
+
+import kitchenpos.domain.MenuGroup;
+
+public class MenuGroupDto {
+    private Long id;
+    private String name;
+
+    public static MenuGroupDto from(MenuGroup menuGroup) {
+        return new MenuGroupDto(menuGroup.getId(), menuGroup.getName());
+    }
+
+    public MenuGroupDto(String name) {
+        this(null, name);
+    }
+
+    public MenuGroupDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public MenuGroup toDomain() {
+        return new MenuGroup(id, name);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/kitchenpos/dto/OrderDto.java
+++ b/src/main/java/kitchenpos/dto/OrderDto.java
@@ -1,24 +1,24 @@
-package kitchenpos.domain;
+package kitchenpos.dto;
+
+import kitchenpos.domain.Order;
+import kitchenpos.domain.OrderLineItem;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class Order {
+public class OrderDto {
+
     private Long id;
     private Long orderTableId;
     private String orderStatus;
     private LocalDateTime orderedTime;
     private List<OrderLineItem> orderLineItems;
 
-    public Order(Long id, Long orderTableId, String orderStatus, LocalDateTime orderedTime) {
-        this(id, orderTableId, orderStatus, orderedTime, null);
+    public static OrderDto from(Order order) {
+        return new OrderDto(order.getId(), order.getOrderTableId(), order.getOrderStatus(), order.getOrderedTime(), order.getOrderLineItems());
     }
 
-    public Order(Long orderTableId, String orderStatus, LocalDateTime orderedTime, List<OrderLineItem> orderLineItems) {
-        this(null, orderTableId, orderStatus, orderedTime, orderLineItems);
-    }
-
-    public Order(Long id, Long orderTableId, String orderStatus, LocalDateTime orderedTime, List<OrderLineItem> orderLineItems) {
+    public OrderDto(Long id, Long orderTableId, String orderStatus, LocalDateTime orderedTime, List<OrderLineItem> orderLineItems) {
         this.id = id;
         this.orderTableId = orderTableId;
         this.orderStatus = orderStatus;
@@ -26,8 +26,8 @@ public class Order {
         this.orderLineItems = orderLineItems;
     }
 
-    public void changeStatus(String orderStatus) {
-        this.orderStatus = orderStatus;
+    public Order toDomain() {
+        return new Order(id, orderTableId, orderStatus, orderedTime, orderLineItems);
     }
 
     public Long getId() {

--- a/src/main/java/kitchenpos/dto/OrderTableDto.java
+++ b/src/main/java/kitchenpos/dto/OrderTableDto.java
@@ -1,23 +1,28 @@
-package kitchenpos.domain;
+package kitchenpos.dto;
 
-public class OrderTable {
+import kitchenpos.domain.OrderTable;
+
+public class OrderTableDto {
+
     private Long id;
     private Long tableGroupId;
     private int numberOfGuests;
     private boolean empty;
 
-    public OrderTable(Long id, Long tableGroupId, int numberOfGuests, boolean empty) {
+    public static OrderTableDto from(OrderTable orderTable) {
+        return new OrderTableDto(orderTable.getId(), orderTable.getTableGroupId(), orderTable.getNumberOfGuests(),
+                orderTable.isEmpty());
+    }
+
+    public OrderTableDto(Long id, Long tableGroupId, int numberOfGuests, boolean empty) {
         this.id = id;
         this.tableGroupId = tableGroupId;
         this.numberOfGuests = numberOfGuests;
         this.empty = empty;
     }
 
-    public void changeNumberOfGuest(int numberOfGuests) {
-        if (numberOfGuests < 0) {
-            throw new IllegalArgumentException();
-        }
-        this.numberOfGuests = numberOfGuests;
+    public OrderTable toDomain() {
+        return new OrderTable(id, tableGroupId, numberOfGuests, empty);
     }
 
     public Long getId() {
@@ -34,10 +39,5 @@ public class OrderTable {
 
     public boolean isEmpty() {
         return empty;
-    }
-
-    public void group(Long tableGroupId) {
-        this.tableGroupId = tableGroupId;
-        this.empty = false;
     }
 }

--- a/src/main/java/kitchenpos/dto/ProductDto.java
+++ b/src/main/java/kitchenpos/dto/ProductDto.java
@@ -1,0 +1,44 @@
+package kitchenpos.dto;
+
+import kitchenpos.domain.Product;
+
+import java.math.BigDecimal;
+
+public class ProductDto {
+
+    private Long id;
+    private String name;
+
+    private BigDecimal price;
+
+    public static ProductDto from(Product product) {
+        return new ProductDto(product.getId(), product.getName(), product.getPrice());
+    }
+
+    public ProductDto(String name, BigDecimal price) {
+        this(null, name, price);
+    }
+
+
+    public ProductDto(Long id, String name, BigDecimal price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+
+    public Product toDomain() {
+        return new Product(id, name, price);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/kitchenpos/dto/TableGroupDto.java
+++ b/src/main/java/kitchenpos/dto/TableGroupDto.java
@@ -1,0 +1,47 @@
+package kitchenpos.dto;
+
+import kitchenpos.domain.OrderTable;
+import kitchenpos.domain.TableGroup;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TableGroupDto {
+    private Long id;
+    private LocalDateTime createdDate;
+    private List<OrderTable> orderTables;
+
+    public static TableGroupDto from(TableGroup tableGroup) {
+        return new TableGroupDto(tableGroup.getId(), tableGroup.getCreatedDate(), tableGroup.getOrderTables());
+    }
+
+    public TableGroupDto(LocalDateTime createdDate) {
+        this(null, createdDate, null);
+    }
+
+    public TableGroupDto(LocalDateTime createdDate, List<OrderTable> orderTables) {
+        this(null, createdDate, orderTables);
+    }
+
+    public TableGroupDto(Long id, LocalDateTime createdDate, List<OrderTable> orderTables) {
+        this.id = id;
+        this.createdDate = createdDate;
+        this.orderTables = orderTables;
+    }
+
+    public TableGroup toDomain() {
+        return new TableGroup(id, createdDate, orderTables);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public List<OrderTable> getOrderTables() {
+        return orderTables;
+    }
+}

--- a/src/main/java/kitchenpos/ui/MenuGroupRestController.java
+++ b/src/main/java/kitchenpos/ui/MenuGroupRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.MenuGroupService;
-import kitchenpos.domain.MenuGroup;
+import kitchenpos.dto.MenuGroupDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,18 +20,16 @@ public class MenuGroupRestController {
     }
 
     @PostMapping("/api/menu-groups")
-    public ResponseEntity<MenuGroup> create(@RequestBody final MenuGroup menuGroup) {
-        final MenuGroup created = menuGroupService.create(menuGroup);
+    public ResponseEntity<MenuGroupDto> create(@RequestBody final MenuGroupDto menuGroup) {
+        final MenuGroupDto created = menuGroupService.create(menuGroup);
         final URI uri = URI.create("/api/menu-groups/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @GetMapping("/api/menu-groups")
-    public ResponseEntity<List<MenuGroup>> list() {
+    public ResponseEntity<List<MenuGroupDto>> list() {
         return ResponseEntity.ok()
-                .body(menuGroupService.list())
-                ;
+                .body(menuGroupService.list());
     }
 }

--- a/src/main/java/kitchenpos/ui/MenuRestController.java
+++ b/src/main/java/kitchenpos/ui/MenuRestController.java
@@ -24,8 +24,7 @@ public class MenuRestController {
         final Menu created = menuService.create(menu);
         final URI uri = URI.create("/api/menus/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @GetMapping("/api/menus")

--- a/src/main/java/kitchenpos/ui/MenuRestController.java
+++ b/src/main/java/kitchenpos/ui/MenuRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.MenuService;
-import kitchenpos.domain.Menu;
+import kitchenpos.dto.MenuDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,17 +20,16 @@ public class MenuRestController {
     }
 
     @PostMapping("/api/menus")
-    public ResponseEntity<Menu> create(@RequestBody final Menu menu) {
-        final Menu created = menuService.create(menu);
+    public ResponseEntity<MenuDto> create(@RequestBody final MenuDto menu) {
+        final MenuDto created = menuService.create(menu);
         final URI uri = URI.create("/api/menus/" + created.getId());
         return ResponseEntity.created(uri)
                 .body(created);
     }
 
     @GetMapping("/api/menus")
-    public ResponseEntity<List<Menu>> list() {
+    public ResponseEntity<List<MenuDto>> list() {
         return ResponseEntity.ok()
-                .body(menuService.list())
-                ;
+                .body(menuService.list());
     }
 }

--- a/src/main/java/kitchenpos/ui/OrderRestController.java
+++ b/src/main/java/kitchenpos/ui/OrderRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.OrderService;
-import kitchenpos.domain.Order;
+import kitchenpos.dto.OrderDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,25 +17,23 @@ public class OrderRestController {
     }
 
     @PostMapping("/api/orders")
-    public ResponseEntity<Order> create(@RequestBody final Order order) {
-        final Order created = orderService.create(order);
+    public ResponseEntity<OrderDto> create(@RequestBody final OrderDto order) {
+        final OrderDto created = orderService.create(order);
         final URI uri = URI.create("/api/orders/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @GetMapping("/api/orders")
-    public ResponseEntity<List<Order>> list() {
+    public ResponseEntity<List<OrderDto>> list() {
         return ResponseEntity.ok()
-                .body(orderService.list())
-                ;
+                .body(orderService.list());
     }
 
     @PutMapping("/api/orders/{orderId}/order-status")
-    public ResponseEntity<Order> changeOrderStatus(
+    public ResponseEntity<OrderDto> changeOrderStatus(
             @PathVariable final Long orderId,
-            @RequestBody final Order order
+            @RequestBody final OrderDto order
     ) {
         return ResponseEntity.ok(orderService.changeOrderStatus(orderId, order));
     }

--- a/src/main/java/kitchenpos/ui/ProductRestController.java
+++ b/src/main/java/kitchenpos/ui/ProductRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.ProductService;
-import kitchenpos.domain.Product;
+import kitchenpos.dto.ProductDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,18 +20,16 @@ public class ProductRestController {
     }
 
     @PostMapping("/api/products")
-    public ResponseEntity<Product> create(@RequestBody final Product product) {
-        final Product created = productService.create(product);
+    public ResponseEntity<ProductDto> create(@RequestBody final ProductDto product) {
+        final ProductDto created = productService.create(product);
         final URI uri = URI.create("/api/products/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @GetMapping("/api/products")
-    public ResponseEntity<List<Product>> list() {
+    public ResponseEntity<List<ProductDto>> list() {
         return ResponseEntity.ok()
-                .body(productService.list())
-                ;
+                .body(productService.list());
     }
 }

--- a/src/main/java/kitchenpos/ui/TableGroupRestController.java
+++ b/src/main/java/kitchenpos/ui/TableGroupRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.TableGroupService;
-import kitchenpos.domain.TableGroup;
+import kitchenpos.dto.TableGroupDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,19 +16,17 @@ public class TableGroupRestController {
     }
 
     @PostMapping("/api/table-groups")
-    public ResponseEntity<TableGroup> create(@RequestBody final TableGroup tableGroup) {
-        final TableGroup created = tableGroupService.create(tableGroup);
+    public ResponseEntity<TableGroupDto> create(@RequestBody final TableGroupDto tableGroup) {
+        final TableGroupDto created = tableGroupService.create(tableGroup);
         final URI uri = URI.create("/api/table-groups/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @DeleteMapping("/api/table-groups/{tableGroupId}")
     public ResponseEntity<Void> ungroup(@PathVariable final Long tableGroupId) {
         tableGroupService.ungroup(tableGroupId);
         return ResponseEntity.noContent()
-                .build()
-                ;
+                .build();
     }
 }

--- a/src/main/java/kitchenpos/ui/TableRestController.java
+++ b/src/main/java/kitchenpos/ui/TableRestController.java
@@ -1,7 +1,7 @@
 package kitchenpos.ui;
 
 import kitchenpos.application.TableService;
-import kitchenpos.domain.OrderTable;
+import kitchenpos.dto.OrderTableDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,25 +17,23 @@ public class TableRestController {
     }
 
     @PostMapping("/api/tables")
-    public ResponseEntity<OrderTable> create(@RequestBody final OrderTable orderTable) {
-        final OrderTable created = tableService.create(orderTable);
+    public ResponseEntity<OrderTableDto> create(@RequestBody final OrderTableDto orderTable) {
+        final OrderTableDto created = tableService.create(orderTable);
         final URI uri = URI.create("/api/tables/" + created.getId());
         return ResponseEntity.created(uri)
-                .body(created)
-                ;
+                .body(created);
     }
 
     @GetMapping("/api/tables")
-    public ResponseEntity<List<OrderTable>> list() {
+    public ResponseEntity<List<OrderTableDto>> list() {
         return ResponseEntity.ok()
-                .body(tableService.list())
-                ;
+                .body(tableService.list());
     }
 
     @PutMapping("/api/tables/{orderTableId}/empty")
-    public ResponseEntity<OrderTable> changeEmpty(
+    public ResponseEntity<OrderTableDto> changeEmpty(
             @PathVariable final Long orderTableId,
-            @RequestBody final OrderTable orderTable
+            @RequestBody final OrderTableDto orderTable
     ) {
         return ResponseEntity.ok()
                 .body(tableService.changeEmpty(orderTableId, orderTable))
@@ -43,12 +41,11 @@ public class TableRestController {
     }
 
     @PutMapping("/api/tables/{orderTableId}/number-of-guests")
-    public ResponseEntity<OrderTable> changeNumberOfGuests(
+    public ResponseEntity<OrderTableDto> changeNumberOfGuests(
             @PathVariable final Long orderTableId,
-            @RequestBody final OrderTable orderTable
+            @RequestBody final OrderTableDto orderTable
     ) {
         return ResponseEntity.ok()
-                .body(tableService.changeNumberOfGuests(orderTableId, orderTable))
-                ;
+                .body(tableService.changeNumberOfGuests(orderTableId, orderTable));
     }
 }

--- a/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuGroupServiceTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.application;
 
+import kitchenpos.dto.MenuGroupDto;
 import kitchenpos.dao.MenuGroupDao;
 import kitchenpos.domain.MenuGroup;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -13,6 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -29,18 +31,15 @@ class MenuGroupServiceTest {
     @Test
     void 메뉴_그룹을_생성한다() {
         // given
-        MenuGroup menuGroup = new MenuGroup();
-        menuGroup.setName("menuGroup");
+        MenuGroupDto menuGroupRequest = new MenuGroupDto("menuGroup");
 
-        MenuGroup expected = new MenuGroup();
-        menuGroup.setId(1L);
-        menuGroup.setName(menuGroup.getName());
+        MenuGroup expected = new MenuGroup(1L, menuGroupRequest.getName());
 
-        given(menuGroupDao.save(menuGroup))
+        given(menuGroupDao.save(any()))
                 .willReturn(expected);
 
         // when
-        MenuGroup result = menuGroupService.create(menuGroup);
+        MenuGroupDto result = menuGroupService.create(menuGroupRequest);
 
         // then
         assertSoftly(softly -> {
@@ -52,15 +51,15 @@ class MenuGroupServiceTest {
     @Test
     void 메뉴_그룹을_전체_조회한다() {
         // given
-        MenuGroup menuGroup1 = new MenuGroup();
-        MenuGroup menuGroup2 = new MenuGroup();
+        MenuGroup menuGroup1 = new MenuGroup("menuGroup1");
+        MenuGroup menuGroup2 = new MenuGroup("menuGroup2");
         List<MenuGroup> expected = List.of(menuGroup1, menuGroup2);
 
         given(menuGroupDao.findAll())
                 .willReturn(expected);
 
         // when
-        List<MenuGroup> result = menuGroupService.list();
+        List<MenuGroupDto> result = menuGroupService.list();
 
         // then
         assertThat(result).hasSize(2);

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -114,12 +114,12 @@ class MenuServiceTest {
     void 가격이_0보다_작은_메뉴를_생성하면_예외를_던진다() {
         // given
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(-1), menu.getMenuGroupId(), menu.getMenuProducts());
-        product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(-1));
 
         // when
         assertThatThrownBy(() -> menuService.create(menuDto))
             .isInstanceOf(IllegalArgumentException.class);
     }
+
 
     @Test
     void 메뉴_상품_가격의_합이_메뉴_가격보다_크면_예외를_던진다() {

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -32,34 +32,26 @@ import static org.mockito.BDDMockito.given;
 @SpringBootTest
 class MenuServiceTest {
 
-    @Autowired
-    private MenuService menuService;
-
-    @MockBean
-    private MenuDao menuDao;
-
-    @MockBean
-    private MenuGroupDao menuGroupDao;
-
-    @MockBean
-    private ProductDao productDao;
-
-    @MockBean
-    private MenuProductDao menuProductDao;
-
     MenuGroup menuGroup;
     MenuProduct menuProduct;
     Menu menu;
     Product product;
+    @Autowired
+    private MenuService menuService;
+    @MockBean
+    private MenuDao menuDao;
+    @MockBean
+    private MenuGroupDao menuGroupDao;
+    @MockBean
+    private ProductDao productDao;
+    @MockBean
+    private MenuProductDao menuProductDao;
 
     @BeforeEach
     void setUp() {
         menuGroup = new MenuGroup(2L, "한마리메뉴");
 
-        menuProduct = new MenuProduct();
-        menuProduct.setProductId(1L);
-        menuProduct.setQuantity(2);
-        menuProduct.setSeq(1L);
+        menuProduct = new MenuProduct(1L, 1L, 2L, 2);
 
         menu = new Menu(1L, "menu", BigDecimal.valueOf(2000), menuGroup.getId(), List.of(menuProduct));
 
@@ -117,7 +109,7 @@ class MenuServiceTest {
 
         // when
         assertThatThrownBy(() -> menuService.create(menuDto))
-            .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 
@@ -125,10 +117,7 @@ class MenuServiceTest {
     void 메뉴_상품_가격의_합이_메뉴_가격보다_크면_예외를_던진다() {
         // given
         List<MenuProduct> menuProducts = menu.getMenuProducts();
-        for (MenuProduct menuProduct : menuProducts) {
-            menuProduct.setQuantity(1L);
-            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
-        }
+        product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(10000), menu.getMenuGroupId(), menu.getMenuProducts());
 
         assert menuProducts.size() != 10;
@@ -142,10 +131,7 @@ class MenuServiceTest {
     void 메뉴_상품_가격의_합이_메뉴의_가격과_같으면_예외를_던지지_않는다() {
         // given
         List<MenuProduct> menuProducts = menu.getMenuProducts();
-        for (MenuProduct menuProduct : menuProducts) {
-            menuProduct.setQuantity(1L);
-            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
-        }
+        product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(1000), menu.getMenuGroupId(), menu.getMenuProducts());
 
         assert menuProducts.size() == 1;
@@ -159,10 +145,7 @@ class MenuServiceTest {
     void 메뉴_상품_가격의_합이_메뉴의_가격보다_작으면_예외를_던지지_않는다() {
         // given
         List<MenuProduct> menuProducts = menu.getMenuProducts();
-        for (MenuProduct menuProduct : menuProducts) {
-            menuProduct.setQuantity(1L);
-            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
-        }
+        product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(500), menu.getMenuGroupId(), menu.getMenuProducts());
 
         assert menuProducts.size() == 1;
@@ -176,11 +159,7 @@ class MenuServiceTest {
     void 메뉴를_전체_조회한다() {
         Menu menu2 = new Menu(2L, "menu2", BigDecimal.valueOf(4000), null, null);
 
-        MenuProduct menuProduct2 = new MenuProduct();
-        menuProduct2.setSeq(1L);
-        menuProduct2.setMenuId(2L);
-        menuProduct2.setQuantity(1L);
-        menuProduct2.setProductId(2L);
+        MenuProduct menuProduct2 = new MenuProduct(1L, 2L, 2L, 1L);
 
         given(menuDao.findAll())
                 .willReturn(List.of(menu, menu2));

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -52,9 +52,7 @@ class MenuServiceTest {
 
     @BeforeEach
     void setUp() {
-        menuGroup = new MenuGroup();
-        menuGroup.setId(2L);
-        menuGroup.setName("한마리메뉴");
+        menuGroup = new MenuGroup(2L, "한마리메뉴");
 
         menuProduct = new MenuProduct();
         menuProduct.setProductId(1L);

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -63,10 +63,7 @@ class MenuServiceTest {
 
         menu = new Menu(1L, "menu", BigDecimal.valueOf(2000), menuGroup.getId(), List.of(menuProduct));
 
-        product = new Product();
-        product.setId(1L);
-        product.setName("후라이드");
-        product.setPrice(new BigDecimal("1000"));
+        product = new Product(1L, "후라이드", BigDecimal.valueOf(1000));
 
         given(menuGroupDao.existsById(any()))
                 .willReturn(true);
@@ -99,7 +96,7 @@ class MenuServiceTest {
     void 가격이_0이상인_상품의_메뉴를_생성한다() {
         // given
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.ZERO, menu.getMenuGroupId(), menu.getMenuProducts());
-        product.setPrice(new BigDecimal("0"));
+        product = new Product(product.getId(), product.getName(), BigDecimal.ZERO);
 
         // when
         MenuDto result = menuService.create(menuDto);
@@ -117,7 +114,7 @@ class MenuServiceTest {
     void 가격이_0보다_작은_메뉴를_생성하면_예외를_던진다() {
         // given
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(-1), menu.getMenuGroupId(), menu.getMenuProducts());
-        product.setPrice(new BigDecimal("-1"));
+        product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(-1));
 
         // when
         assertThatThrownBy(() -> menuService.create(menuDto))
@@ -130,7 +127,7 @@ class MenuServiceTest {
         List<MenuProduct> menuProducts = menu.getMenuProducts();
         for (MenuProduct menuProduct : menuProducts) {
             menuProduct.setQuantity(1L);
-            product.setPrice(BigDecimal.valueOf(1000));
+            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         }
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(10000), menu.getMenuGroupId(), menu.getMenuProducts());
 
@@ -147,7 +144,7 @@ class MenuServiceTest {
         List<MenuProduct> menuProducts = menu.getMenuProducts();
         for (MenuProduct menuProduct : menuProducts) {
             menuProduct.setQuantity(1L);
-            product.setPrice(BigDecimal.valueOf(1000));
+            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         }
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(1000), menu.getMenuGroupId(), menu.getMenuProducts());
 
@@ -164,7 +161,7 @@ class MenuServiceTest {
         List<MenuProduct> menuProducts = menu.getMenuProducts();
         for (MenuProduct menuProduct : menuProducts) {
             menuProduct.setQuantity(1L);
-            product.setPrice(BigDecimal.valueOf(1000));
+            product = new Product(product.getId(), product.getName(), BigDecimal.valueOf(1000));
         }
         MenuDto menuDto = new MenuDto(menu.getId(), menu.getName(), BigDecimal.valueOf(500), menu.getMenuGroupId(), menu.getMenuProducts());
 

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -53,8 +53,7 @@ class OrderServiceTest {
         orderLineItem.setMenuId(1L);
         List<OrderLineItem> orderLineItems = List.of(orderLineItem);
 
-        OrderTable orderTable = new OrderTable();
-        orderTable.setId(1L);
+        OrderTable orderTable = new OrderTable(1L, null, 0 , false);
 
         Order order = new Order(1L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
 
@@ -86,8 +85,7 @@ class OrderServiceTest {
         orderLineItem.setMenuId(1L);
         List<OrderLineItem> orderLineItems = List.of(orderLineItem);
 
-        OrderTable orderTable = new OrderTable();
-        orderTable.setId(1L);
+        OrderTable orderTable = new OrderTable(1L, null, 0 ,false);
 
         Order order1 = new Order(1L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
         Order order2 = new Order(2L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -8,6 +8,7 @@ import kitchenpos.domain.Order;
 import kitchenpos.domain.OrderLineItem;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
+import kitchenpos.dto.OrderDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -15,13 +16,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
@@ -45,33 +49,26 @@ class OrderServiceTest {
     @Test
     void 주문을_생성한다() {
         // given
-        Order order = new Order();
-        order.setId(1L);
-
         OrderLineItem orderLineItem = new OrderLineItem();
         orderLineItem.setMenuId(1L);
         List<OrderLineItem> orderLineItems = List.of(orderLineItem);
-        order.setOrderLineItems(orderLineItems);
 
         OrderTable orderTable = new OrderTable();
         orderTable.setId(1L);
-        order.setOrderTableId(orderTable.getId());
 
-        final List<Long> menuIds = orderLineItems.stream()
-                .map(OrderLineItem::getMenuId)
-                .collect(Collectors.toList());
+        Order order = new Order(1L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
 
-        given(menuDao.countByIdIn(menuIds))
+        given(menuDao.countByIdIn(any()))
                 .willReturn((long) orderLineItems.size());
-        given(orderTableDao.findById(order.getOrderTableId()))
+        given(orderTableDao.findById(any()))
                 .willReturn(Optional.of(orderTable));
-        given(orderDao.save(order))
+        given(orderDao.save(any()))
                 .willReturn(order);
-        given(orderLineItemDao.save(orderLineItem))
+        given(orderLineItemDao.save(any()))
                 .willReturn(orderLineItem);
 
         // when
-        Order result = orderService.create(order);
+        OrderDto result = orderService.create(OrderDto.from(order));
 
         // then
         assertSoftly(softly -> {
@@ -85,44 +82,45 @@ class OrderServiceTest {
     @Test
     void 주문을_전체_조회한다() {
         // given
-        Order order1 = new Order();
-        Order order2 = new Order();
-        List<Order> expected = List.of(order1, order2);
+        OrderLineItem orderLineItem = new OrderLineItem();
+        orderLineItem.setMenuId(1L);
+        List<OrderLineItem> orderLineItems = List.of(orderLineItem);
+
+        OrderTable orderTable = new OrderTable();
+        orderTable.setId(1L);
+
+        Order order1 = new Order(1L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
+        Order order2 = new Order(2L, orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), orderLineItems);
 
         given(orderDao.findAll())
-                .willReturn(expected);
+                .willReturn(List.of(order1, order2));
 
         // when
-        List<Order> result = orderService.list();
+        List<OrderDto> result = orderService.list();
 
         // then
-        assertThat(result).containsExactly(order1, order2);
+        assertThat(result).hasSize(2);
     }
 
     @ParameterizedTest(name = "주문 상태를 {0}에서 {1}로 변경한다")
     @CsvSource(value = {"COOKING:MEAL", "COOKING:COMPLETION", "MEAL:COMPLETION", "COOKING:COOKING", "MEAL:MEAL"}, delimiter = ':')
     void 주문_상태를_변경한다(OrderStatus fromStatus, OrderStatus toStatus) {
         // given
-        Order order = new Order();
-        order.setId(1L);
-        order.setOrderStatus(fromStatus.name());
-
         OrderLineItem orderLineItem = new OrderLineItem();
         orderLineItem.setSeq(1L);
         orderLineItem.setOrderId(1L);
         List<OrderLineItem> orderLineItems = List.of(orderLineItem);
-        order.setOrderLineItems(orderLineItems);
 
-        Order changeOrder = new Order();
-        changeOrder.setOrderStatus(toStatus.name());
+        Order order = new Order(1L, fromStatus.name(), LocalDateTime.now(), orderLineItems);
+        Order changeOrder = new Order(1L, toStatus.name(), LocalDateTime.now(), orderLineItems);
 
-        given(orderDao.findById(order.getId()))
+        given(orderDao.findById(any()))
                 .willReturn(Optional.of(order));
-        given(orderLineItemDao.findAllByOrderId(order.getId()))
+        given(orderLineItemDao.findAllByOrderId(any()))
                 .willReturn(orderLineItems);
 
         // when
-        Order result = orderService.changeOrderStatus(order.getId(), changeOrder);
+        OrderDto result = orderService.changeOrderStatus(order.getId(), OrderDto.from(changeOrder));
 
         // then
         assertSoftly(softly -> {
@@ -135,26 +133,22 @@ class OrderServiceTest {
     @CsvSource(value = {"COMPLETION:MEAL", "COMPLETION:COOKING", "COMPLETION:COMPLETION"}, delimiter = ':')
     void 주문_상태를_변경하면_예외를_던진다(OrderStatus fromStatus, OrderStatus toStatus) {
         // given
-        Order order = new Order();
-        order.setId(1L);
-        order.setOrderStatus(fromStatus.name());
-
         OrderLineItem orderLineItem = new OrderLineItem();
         orderLineItem.setSeq(1L);
         orderLineItem.setOrderId(1L);
         List<OrderLineItem> orderLineItems = List.of(orderLineItem);
-        order.setOrderLineItems(orderLineItems);
 
-        Order changeOrder = new Order();
-        changeOrder.setOrderStatus(toStatus.name());
+        Order order = new Order(1L, fromStatus.name(), LocalDateTime.now(), orderLineItems);
+        Order changeOrder = new Order(1L, toStatus.name(), LocalDateTime.now(), orderLineItems);
 
-        given(orderDao.findById(order.getId()))
+        given(orderDao.findById(any()))
                 .willReturn(Optional.of(order));
-        given(orderLineItemDao.findAllByOrderId(order.getId()))
+        given(orderLineItemDao.findAllByOrderId(any()))
                 .willReturn(orderLineItems);
 
+
         // when & then
-        assertThatThrownBy(() -> orderService.changeOrderStatus(order.getId(), changeOrder))
+        assertThatThrownBy(() -> orderService.changeOrderStatus(order.getId(), OrderDto.from(changeOrder)))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/kitchenpos/application/ProductServiceTest.java
+++ b/src/test/java/kitchenpos/application/ProductServiceTest.java
@@ -2,6 +2,7 @@ package kitchenpos.application;
 
 import kitchenpos.dao.ProductDao;
 import kitchenpos.domain.Product;
+import kitchenpos.dto.ProductDto;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import java.util.List;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -31,16 +33,13 @@ class ProductServiceTest {
     @Test
     void 상품을_생성한다() {
         // given
-        Product product = new Product();
-        product.setId(1L);
-        product.setName("product");
-        product.setPrice(new BigDecimal("1000"));
+        ProductDto product = new ProductDto(1L, "product", BigDecimal.valueOf(1000));
 
-        given(productDao.save(product))
-                .willReturn(product);
+        given(productDao.save(any()))
+                .willReturn(product.toDomain());
 
         // when
-        Product result = productService.create(product);
+        ProductDto result = productService.create(product);
 
         // then
         assertSoftly(softly -> {
@@ -53,9 +52,7 @@ class ProductServiceTest {
     @Test
     void 가격이_0원_보다_작은_상품을_생성하면_예외를_던진다() {
         // given
-        Product product = new Product();
-        product.setName("product");
-        product.setPrice(new BigDecimal("-1"));
+        ProductDto product = new ProductDto("product", BigDecimal.valueOf(-1));
 
         // when & then
         assertThatThrownBy(() -> productService.create(product))
@@ -65,15 +62,16 @@ class ProductServiceTest {
     @Test
     void 상품을_전체_조회한다() {
         // given
-        Product product1 = new Product();
-        Product product2 = new Product();
+        Product product1 = new Product(1L, "product1", BigDecimal.valueOf(1000));
+        Product product2 = new Product(1L, "product2", BigDecimal.valueOf(2000));
+
         List<Product> expected = List.of(product1, product2);
 
         given(productDao.findAll())
                 .willReturn(expected);
 
         // when
-        List<Product> result = productService.list();
+        List<ProductDto> result = productService.list();
 
         // then
         assertThat(result).hasSize(2);

--- a/src/test/java/kitchenpos/application/TableGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableGroupServiceTest.java
@@ -45,17 +45,12 @@ class TableGroupServiceTest {
     @Test
     void 단체_지정을_생성한다() {
         // given
-        OrderTable orderTable1 = new OrderTable();
-        OrderTable orderTable2 = new OrderTable();
-        orderTable1.setId(1L);
-        orderTable2.setId(2L);
-        orderTable1.setEmpty(true);
-        orderTable2.setEmpty(true);
-
+        OrderTable orderTable1 = new OrderTable(1L, null, 2, true);
+        OrderTable orderTable2 = new OrderTable(2L, null, 3, true);
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
+
         TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
         TableGroup tableGroup = tableGroupDto.toDomain();
-
         List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)
                 .collect(Collectors.toList());
@@ -75,14 +70,10 @@ class TableGroupServiceTest {
     @Test
     void 비어있지_않은_테이블을_단체_지정하면_예외를_던진다() {
         // given
-        OrderTable orderTable1 = new OrderTable();
-        OrderTable orderTable2 = new OrderTable();
-        orderTable1.setId(1L);
-        orderTable2.setId(2L);
-        orderTable1.setEmpty(false);
-        orderTable2.setEmpty(false);
-
+        OrderTable orderTable1 = new OrderTable(1L, 1L, 2, false);
+        OrderTable orderTable2 = new OrderTable(2L, 1L, 3, false);
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
+
         TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
         TableGroup tableGroup = tableGroupDto.toDomain();
 
@@ -103,16 +94,10 @@ class TableGroupServiceTest {
     @Test
     void 이미_단체_지정된_테이블을_단체_지정하면_예외를_던진다() {
         // given
-        OrderTable orderTable1 = new OrderTable();
-        OrderTable orderTable2 = new OrderTable();
-        orderTable1.setId(1L);
-        orderTable2.setId(2L);
-        orderTable1.setEmpty(true);
-        orderTable2.setEmpty(true);
-        orderTable1.setTableGroupId(1L);
-        orderTable2.setTableGroupId(1L);
-
+        OrderTable orderTable1 = new OrderTable(1L, 1L, 2, true);
+        OrderTable orderTable2 = new OrderTable(2L, 1L, 3, true);
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
+
         TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
         TableGroup tableGroup = tableGroupDto.toDomain();
 
@@ -133,14 +118,10 @@ class TableGroupServiceTest {
     @Test
     void 단체_지정을_해제한다() {
         // given
-        OrderTable orderTable1 = new OrderTable();
-        OrderTable orderTable2 = new OrderTable();
-        orderTable1.setId(1L);
-        orderTable2.setId(2L);
-        orderTable1.setEmpty(true);
-        orderTable2.setEmpty(true);
-
+        OrderTable orderTable1 = new OrderTable(1L, 1L, 2, true);
+        OrderTable orderTable2 = new OrderTable(2L, 1L, 3, true);
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
+
         TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
         TableGroup tableGroup = tableGroupDto.toDomain();
 

--- a/src/test/java/kitchenpos/application/TableGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableGroupServiceTest.java
@@ -6,6 +6,7 @@ import kitchenpos.dao.TableGroupDao;
 import kitchenpos.domain.OrderStatus;
 import kitchenpos.domain.OrderTable;
 import kitchenpos.domain.TableGroup;
+import kitchenpos.dto.TableGroupDto;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -42,7 +45,6 @@ class TableGroupServiceTest {
     @Test
     void 단체_지정을_생성한다() {
         // given
-        TableGroup tableGroup = new TableGroup();
         OrderTable orderTable1 = new OrderTable();
         OrderTable orderTable2 = new OrderTable();
         orderTable1.setId(1L);
@@ -51,7 +53,8 @@ class TableGroupServiceTest {
         orderTable2.setEmpty(true);
 
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
-        tableGroup.setOrderTables(orderTables);
+        TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
+        TableGroup tableGroup = tableGroupDto.toDomain();
 
         List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)
@@ -59,11 +62,11 @@ class TableGroupServiceTest {
 
         given(orderTableDao.findAllByIdIn(orderTableIds))
                 .willReturn(orderTables);
-        given(tableGroupDao.save(tableGroup))
+        given(tableGroupDao.save(any()))
                 .willReturn(tableGroup);
 
         // when
-        TableGroup result = tableGroupService.create(tableGroup);
+        TableGroupDto result = tableGroupService.create(tableGroupDto);
 
         // then
         assertThat(result.getOrderTables()).containsAll(orderTables);
@@ -72,7 +75,6 @@ class TableGroupServiceTest {
     @Test
     void 비어있지_않은_테이블을_단체_지정하면_예외를_던진다() {
         // given
-        TableGroup tableGroup = new TableGroup();
         OrderTable orderTable1 = new OrderTable();
         OrderTable orderTable2 = new OrderTable();
         orderTable1.setId(1L);
@@ -81,7 +83,8 @@ class TableGroupServiceTest {
         orderTable2.setEmpty(false);
 
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
-        tableGroup.setOrderTables(orderTables);
+        TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
+        TableGroup tableGroup = tableGroupDto.toDomain();
 
         List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)
@@ -93,14 +96,13 @@ class TableGroupServiceTest {
                 .willReturn(tableGroup);
 
         // when & then
-        assertThatThrownBy(() -> tableGroupService.create(tableGroup))
+        assertThatThrownBy(() -> tableGroupService.create(tableGroupDto))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 이미_단체_지정된_테이블을_단체_지정하면_예외를_던진다() {
         // given
-        TableGroup tableGroup = new TableGroup();
         OrderTable orderTable1 = new OrderTable();
         OrderTable orderTable2 = new OrderTable();
         orderTable1.setId(1L);
@@ -111,7 +113,8 @@ class TableGroupServiceTest {
         orderTable2.setTableGroupId(1L);
 
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
-        tableGroup.setOrderTables(orderTables);
+        TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
+        TableGroup tableGroup = tableGroupDto.toDomain();
 
         List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)
@@ -123,14 +126,13 @@ class TableGroupServiceTest {
                 .willReturn(tableGroup);
 
         // when & then
-        assertThatThrownBy(() -> tableGroupService.create(tableGroup))
+        assertThatThrownBy(() -> tableGroupService.create(tableGroupDto))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 단체_지정을_해제한다() {
         // given
-        TableGroup tableGroup = new TableGroup();
         OrderTable orderTable1 = new OrderTable();
         OrderTable orderTable2 = new OrderTable();
         orderTable1.setId(1L);
@@ -139,7 +141,8 @@ class TableGroupServiceTest {
         orderTable2.setEmpty(true);
 
         List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
-        tableGroup.setOrderTables(orderTables);
+        TableGroupDto tableGroupDto = new TableGroupDto(LocalDateTime.now(), orderTables);
+        TableGroup tableGroup = tableGroupDto.toDomain();
 
         List<Long> orderTableIds = orderTables.stream()
                 .map(OrderTable::getId)


### PR DESCRIPTION
안녕하세요 필립! 마코입니다.

저는 다음과 같은 이유로 JPA로 넘어가지 않고 JDBC를 그대로 사용한 상태에서 리팩터링을 진행했습니다.

1. JPA로 넘어가면 좋겠지만 현업에서 여건상 사용할 수 없는 상황도 있을 수 있다고 생각해 JDBC를 사용하는 상황에서 리팩토링을 해보고 싶었습니다.
2. 이미 잘 동작하고 있는 시스템이고 서비스가 엄청나게 복잡한 수준은 아니다. 

새로 시작하는 프로젝트라면 비즈니스 로직이 있고 영속 로직과 섞이기 때문에 JPA를 선택할 것 같지만 위 이유로 JDBC를 유지하는 것도 괜찮다는 생각이 듭니다.

우선, DB로직을 제외하고 최대한 도메인으로 넣고, setter를 제거했는데요, 객체가 생성된 이후에 의존 객체를 매핑해주어야 하는 경우들이 생기더라고요. 이러한 경우 다음과 같은 방법이 있을 것이라고 생각했습니다.
1. new로 새로운 객체를 생성한다. 
2. setter를 그냥 사용한다(의미가 있다면 의미가 있는 이름을 부여) 
3. repository를 구현하여 연관된 객체도 함께 조회한다. 

1번도 인스턴스 변수가 많다면 매번 생성해주는 것이 복잡하기도하고 3번의 방법도 직접 매핑작업을 해주는게 작업이 많을 것 같습니다. 그래서 저는 의존 객체를 매핑해주어야 하는 경우에 한해 setter를 사용하는 것도 괜찮다는 생각이 들었습니다.

이에 대해서 필립의 의견은 어떤지 궁금합니다!