### PR TITLE
[레거시 코드 리팩터링 - 3단계] 엔델(김민준) 미션 제출합니다.

### DIFF
--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -51,8 +51,8 @@ public class MenuService {
         final Menu savedMenu = menuRepository.save(new Menu(request.getName(), request.getPrice(), request.getMenuGroupId(), Collections.emptyList()));
 
         for (final MenuCreateRequest.MenuProductCreate menuProductCreate : request.getMenuProductCreates()) {
-            final MenuProduct menuProduct = menuProductRepository.save(new MenuProduct(savedMenu, productRepository.findById(menuProductCreate.getProductId()).orElseThrow(IllegalAccessError::new), menuProductCreate.getQuantity()));
-            savedMenu.addMenuProduct(menuProduct);
+            final Product product = productRepository.findById(menuProductCreate.getProductId()).orElseThrow(IllegalAccessError::new);
+            savedMenu.addMenuProduct(new MenuProduct(product.getId(), menuProductCreate.getQuantity()));
         }
 
         return savedMenu.getId();

--- a/src/main/java/kitchenpos/menu/application/MenuService.java
+++ b/src/main/java/kitchenpos/menu/application/MenuService.java
@@ -7,15 +7,12 @@ import kitchenpos.menu.domain.MenuGroupRepository;
 import kitchenpos.menu.domain.MenuProduct;
 import kitchenpos.menu.domain.MenuProductRepository;
 import kitchenpos.menu.domain.MenuRepository;
-import kitchenpos.menu.domain.vo.Price;
 import kitchenpos.product.domain.Product;
 import kitchenpos.product.domain.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,34 +37,18 @@ public class MenuService {
 
     @Transactional
     public Long create(final MenuCreateRequest request) {
-        final Price price = new Price(request.getPrice());
-
         if (!menuGroupRepository.existsById(request.getMenuGroupId())) {
             throw new IllegalArgumentException();
         }
 
-        validatePriceLessThenProductsSum(request.getMenuProductCreates(), price);
+        final List<MenuProduct> menuProducts = request.getMenuProductCreates().stream().map(menuProductCreate -> {
+            final Product product = productRepository.findById(menuProductCreate.getProductId()).orElseThrow(IllegalArgumentException::new);
+            return new MenuProduct(product, menuProductCreate.getQuantity());
+        }).collect(Collectors.toList());
 
-        final Menu savedMenu = menuRepository.save(new Menu(request.getName(), request.getPrice(), request.getMenuGroupId(), Collections.emptyList()));
-
-        for (final MenuCreateRequest.MenuProductCreate menuProductCreate : request.getMenuProductCreates()) {
-            final Product product = productRepository.findById(menuProductCreate.getProductId()).orElseThrow(IllegalAccessError::new);
-            savedMenu.addMenuProduct(new MenuProduct(product.getId(), menuProductCreate.getQuantity()));
-        }
+        final Menu savedMenu = menuRepository.save(new Menu(request.getName(), request.getPrice(), request.getMenuGroupId(), menuProducts));
 
         return savedMenu.getId();
-    }
-
-    private void validatePriceLessThenProductsSum(final List<MenuCreateRequest.MenuProductCreate> menuProductCreates, final Price price) {
-        BigDecimal sum = BigDecimal.ZERO;
-        for (final MenuCreateRequest.MenuProductCreate menuProductCreate : menuProductCreates) {
-            final Product product = productRepository.findById(menuProductCreate.getProductId())
-                    .orElseThrow(IllegalArgumentException::new);
-            sum = sum.add(product.getPrice().multiply(BigDecimal.valueOf(menuProductCreate.getQuantity())));
-        }
-        if (price.compareTo(new Price(sum)) > 0) {
-            throw new IllegalArgumentException();
-        }
     }
 
     public List<MenuResponse> list() {

--- a/src/main/java/kitchenpos/menu/domain/Menu.java
+++ b/src/main/java/kitchenpos/menu/domain/Menu.java
@@ -2,6 +2,7 @@ package kitchenpos.menu.domain;
 
 import kitchenpos.menu.domain.vo.Price;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -9,6 +10,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -26,7 +28,8 @@ public class Menu {
     private Price price;
     @Column(nullable = false)
     private Long menuGroupId;
-    @OneToMany(mappedBy = "menu", fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "menu_id", nullable = false)
     private List<MenuProduct> menuProducts = new ArrayList<>();
 
     public Menu() {
@@ -61,7 +64,6 @@ public class Menu {
 
     public void addMenuProduct(final MenuProduct menuProduct) {
         this.menuProducts = new ArrayList<>(this.menuProducts);
-        menuProduct.setMenu(this);
         this.menuProducts.add(menuProduct);
     }
 }

--- a/src/main/java/kitchenpos/menu/domain/Menu.java
+++ b/src/main/java/kitchenpos/menu/domain/Menu.java
@@ -36,10 +36,21 @@ public class Menu {
     }
 
     public Menu(final String name, final BigDecimal price, final Long menuGroupId, final List<MenuProduct> menuProducts) {
-        this.name = name;
         this.price = new Price(price);
+        validatePriceLessThenProductsSum(menuProducts, price);
+        this.name = name;
         this.menuGroupId = menuGroupId;
         this.menuProducts = menuProducts;
+    }
+
+    private void validatePriceLessThenProductsSum(final List<MenuProduct> menuProducts, final BigDecimal price) {
+        BigDecimal sum = BigDecimal.ZERO;
+        for (final MenuProduct menuProduct : menuProducts) {
+            sum = sum.add(menuProduct.getProduct().getPrice().multiply(BigDecimal.valueOf(menuProduct.getQuantity())));
+        }
+        if (price.compareTo(sum) > 0) {
+            throw new IllegalArgumentException();
+        }
     }
 
     public Long getId() {
@@ -60,10 +71,5 @@ public class Menu {
 
     public List<MenuProduct> getMenuProducts() {
         return menuProducts;
-    }
-
-    public void addMenuProduct(final MenuProduct menuProduct) {
-        this.menuProducts = new ArrayList<>(this.menuProducts);
-        this.menuProducts.add(menuProduct);
     }
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProduct.java
@@ -1,10 +1,14 @@
 package kitchenpos.menu.domain;
 
+import kitchenpos.product.domain.Product;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 @Entity
 public class MenuProduct {
@@ -12,16 +16,17 @@ public class MenuProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long seq;
-    @Column(name = "product_id", nullable = false)
-    private Long productId;
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
     @Column(nullable = false)
     private long quantity;
 
     public MenuProduct() {
     }
 
-    public MenuProduct(final Long productId, final long quantity) {
-        this.productId = productId;
+    public MenuProduct(final Product product, final long quantity) {
+        this.product = product;
         this.quantity = quantity;
     }
 
@@ -29,8 +34,8 @@ public class MenuProduct {
         return seq;
     }
 
-    public Long getProductId() {
-        return productId;
+    public Product getProduct() {
+        return product;
     }
 
     public long getQuantity() {

--- a/src/main/java/kitchenpos/menu/domain/MenuProduct.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProduct.java
@@ -1,14 +1,10 @@
 package kitchenpos.menu.domain;
 
-import kitchenpos.product.domain.Product;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 
 @Entity
 public class MenuProduct {
@@ -16,21 +12,16 @@ public class MenuProduct {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long seq;
-    @ManyToOne
-    @JoinColumn(name = "menu_id", nullable = false)
-    private Menu menu;
-    @ManyToOne
-    @JoinColumn(name = "product_id", nullable = false)
-    private Product product;
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
     @Column(nullable = false)
     private long quantity;
 
     public MenuProduct() {
     }
 
-    public MenuProduct(final Menu menu, final Product product, final long quantity) {
-        this.menu = menu;
-        this.product = product;
+    public MenuProduct(final Long productId, final long quantity) {
+        this.productId = productId;
         this.quantity = quantity;
     }
 
@@ -38,19 +29,11 @@ public class MenuProduct {
         return seq;
     }
 
-    public Menu getMenu() {
-        return menu;
-    }
-
-    public Product getProduct() {
-        return product;
+    public Long getProductId() {
+        return productId;
     }
 
     public long getQuantity() {
         return quantity;
-    }
-
-    public void setMenu(Menu menu) {
-        this.menu = menu;
     }
 }

--- a/src/main/java/kitchenpos/menu/domain/MenuProductRepository.java
+++ b/src/main/java/kitchenpos/menu/domain/MenuProductRepository.java
@@ -2,8 +2,5 @@ package kitchenpos.menu.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface MenuProductRepository extends JpaRepository<MenuProduct, Long> {
-    List<MenuProduct> findAllByMenu(final Menu menu);
 }

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class OrderService {
@@ -50,7 +49,10 @@ public class OrderService {
             throw new IllegalArgumentException();
         }
 
-        Order order = new Order(orderTable, OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
+        if (orderTable.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
+        final Order order = new Order(orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
         final Order savedOrder = orderRepository.save(order);
 
         for (final OrderCreateRequest.OrderLineItemCreate orderLineItem : orderLineItemCreates) {

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -41,11 +41,11 @@ public class OrderService {
 
     @Transactional
     public Long create(final OrderCreateRequest request) {
-        final List<OrderCreateRequest.OrderLineItemCreate> orderLineItemCreates = request.getOrderLineItemCreates();
+        final List<OrderCreateRequest.MenuSnapShot> menuSnapShots = request.getMenuSnapShots();
 
         final OrderTable orderTable = orderTableRepository.findById(request.getOrderTableId())
                 .orElseThrow(IllegalArgumentException::new);
-        if (CollectionUtils.isEmpty(orderLineItemCreates)) {
+        if (CollectionUtils.isEmpty(menuSnapShots)) {
             throw new IllegalArgumentException();
         }
 
@@ -55,9 +55,10 @@ public class OrderService {
         final Order order = new Order(orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
         final Order savedOrder = orderRepository.save(order);
 
-        for (final OrderCreateRequest.OrderLineItemCreate orderLineItem : orderLineItemCreates) {
-            final Menu menu = menuRepository.findById(orderLineItem.getMenuId()).orElseThrow(IllegalArgumentException::new);
-            savedOrder.addOrderLineItem(new OrderLineItem(menu.getId(), orderLineItem.getQuantity()));
+        for (final OrderCreateRequest.MenuSnapShot menuSnapShot : menuSnapShots) {
+            final Menu menu = menuRepository.findById(menuSnapShot.getMenuId()).orElseThrow(IllegalArgumentException::new);
+            OrderSnapShotValidator.validate(menu,menuSnapShot);
+            savedOrder.addOrderLineItem(new OrderLineItem(menu.getId(), menuSnapShot.getQuantity()));
         }
 
         return savedOrder.getId();

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -58,7 +58,7 @@ public class OrderService {
         for (final OrderCreateRequest.MenuSnapShot menuSnapShot : menuSnapShots) {
             final Menu menu = menuRepository.findById(menuSnapShot.getMenuId()).orElseThrow(IllegalArgumentException::new);
             OrderSnapShotValidator.validate(menu,menuSnapShot);
-            savedOrder.addOrderLineItem(new OrderLineItem(menu.getId(), menuSnapShot.getQuantity()));
+            savedOrder.addOrderLineItem(new OrderLineItem(menu.getId(), menu.getName(), menu.getPrice(), menuSnapShot.getQuantity()));
         }
 
         return savedOrder.getId();

--- a/src/main/java/kitchenpos/order/application/OrderService.java
+++ b/src/main/java/kitchenpos/order/application/OrderService.java
@@ -1,5 +1,6 @@
 package kitchenpos.order.application;
 
+import kitchenpos.menu.domain.Menu;
 import kitchenpos.menu.domain.MenuRepository;
 import kitchenpos.order.application.dto.OrderCreateRequest;
 import kitchenpos.order.application.dto.OrderResponse;
@@ -53,7 +54,8 @@ public class OrderService {
         final Order savedOrder = orderRepository.save(order);
 
         for (final OrderCreateRequest.OrderLineItemCreate orderLineItem : orderLineItemCreates) {
-            savedOrder.addOrderLineItem(orderLineItemRepository.save(new OrderLineItem(savedOrder, menuRepository.findById(orderLineItem.getMenuId()).orElseThrow(IllegalArgumentException::new), orderLineItem.getQuantity())));
+            final Menu menu = menuRepository.findById(orderLineItem.getMenuId()).orElseThrow(IllegalArgumentException::new);
+            savedOrder.addOrderLineItem(new OrderLineItem(menu.getId(), orderLineItem.getQuantity()));
         }
 
         return savedOrder.getId();

--- a/src/main/java/kitchenpos/order/application/OrderSnapShotValidator.java
+++ b/src/main/java/kitchenpos/order/application/OrderSnapShotValidator.java
@@ -1,0 +1,55 @@
+package kitchenpos.order.application;
+
+import kitchenpos.menu.domain.Menu;
+import kitchenpos.menu.domain.MenuProduct;
+import kitchenpos.order.application.dto.OrderCreateRequest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class OrderSnapShotValidator {
+    public static void validate(final Menu menu, final OrderCreateRequest.MenuSnapShot menuSnapShot) {
+        if (!menu.getName().equals(menuSnapShot.getName())) {
+            throw new IllegalArgumentException();
+        }
+        if (menu.getPrice().compareTo(menuSnapShot.getPrice()) != 0) {
+            throw new IllegalArgumentException();
+        }
+        validateProductSnapShots(menu.getMenuProducts(), menuSnapShot.getProductSnapShots());
+    }
+
+    private static void validateProductSnapShots(final List<MenuProduct> menuProducts, final List<OrderCreateRequest.MenuSnapShot.ProductSnapShot> productSnapShots) {
+        if (menuProducts.size() != productSnapShots.size()) {
+            throw new IllegalArgumentException();
+        }
+        final List<MenuProduct> sortedMenuProducts = menuProducts.stream()
+                .sorted((o1, o2) -> Math.toIntExact(o1.getSeq() - o2.getSeq()))
+                .collect(Collectors.toList());
+        final List<OrderCreateRequest.MenuSnapShot.ProductSnapShot> sortedProductSnapShots = productSnapShots.stream()
+                .sorted((o1, o2) -> Math.toIntExact(o1.getProductId() - o2.getProductId()))
+                .collect(Collectors.toList());
+        for (int i = 0; i < menuProducts.size(); i++) {
+            final MenuProduct menuProduct = sortedMenuProducts.get(i);
+            final OrderCreateRequest.MenuSnapShot.ProductSnapShot productSnapShot = sortedProductSnapShots.get(i);
+            validateProductSnapShot(menuProduct, productSnapShot);
+        }
+    }
+
+    private static void validateProductSnapShot(final MenuProduct menuProduct, final OrderCreateRequest.MenuSnapShot.ProductSnapShot productSnapShot) {
+        if (!menuProduct.getSeq().equals(productSnapShot.getMenuProductId())) {
+            throw new IllegalArgumentException();
+        }
+        if (!(menuProduct.getQuantity() == productSnapShot.getQuantity())) {
+            throw new IllegalArgumentException();
+        }
+        if (!menuProduct.getProduct().getId().equals(productSnapShot.getProductId())) {
+            throw new IllegalArgumentException();
+        }
+        if (!menuProduct.getProduct().getName().equals(productSnapShot.getName())) {
+            throw new IllegalArgumentException();
+        }
+        if (!menuProduct.getProduct().getPrice().equals(productSnapShot.getPrice())) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/kitchenpos/order/application/OrderStatusValidateEventListener.java
+++ b/src/main/java/kitchenpos/order/application/OrderStatusValidateEventListener.java
@@ -2,7 +2,7 @@ package kitchenpos.order.application;
 
 import kitchenpos.order.domain.OrderRepository;
 import kitchenpos.order.domain.OrderStatus;
-import kitchenpos.table.domain.OrderTableChangeEmptyValidateOrderStatusEvent;
+import kitchenpos.table.domain.OrderTableEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -19,7 +19,7 @@ public final class OrderStatusValidateEventListener {
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void validateOrderStatus(final OrderTableChangeEmptyValidateOrderStatusEvent event) {
+    public void validateOrderStatus(final OrderTableEvent event) {
         final Long orderTableId = event.getOrderTableId();
 
         if (orderRepository.existsByOrderTableIdAndOrderStatusIn(

--- a/src/main/java/kitchenpos/order/application/OrderStatusValidateEventListener.java
+++ b/src/main/java/kitchenpos/order/application/OrderStatusValidateEventListener.java
@@ -1,0 +1,30 @@
+package kitchenpos.order.application;
+
+import kitchenpos.order.domain.OrderRepository;
+import kitchenpos.order.domain.OrderStatus;
+import kitchenpos.table.domain.OrderTableChangeEmptyValidateOrderStatusEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Arrays;
+
+@Component
+public final class OrderStatusValidateEventListener {
+
+    private final OrderRepository orderRepository;
+
+    public OrderStatusValidateEventListener(final OrderRepository orderRepository) {
+        this.orderRepository = orderRepository;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void validateOrderStatus(final OrderTableChangeEmptyValidateOrderStatusEvent event) {
+        final Long orderTableId = event.getOrderTableId();
+
+        if (orderRepository.existsByOrderTableIdAndOrderStatusIn(
+                orderTableId, Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/kitchenpos/order/application/dto/OrderCreateRequest.java
+++ b/src/main/java/kitchenpos/order/application/dto/OrderCreateRequest.java
@@ -1,32 +1,39 @@
 package kitchenpos.order.application.dto;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public final class OrderCreateRequest {
 
     private final Long orderTableId;
-    private final List<OrderLineItemCreate> orderLineItemCreates;
+    private final List<MenuSnapShot> menuSnapShots;
 
-    public OrderCreateRequest(final Long orderTableId, final List<OrderLineItemCreate> orderLineItemCreates) {
+    public OrderCreateRequest(final Long orderTableId, final List<MenuSnapShot> menuSnapShots) {
         this.orderTableId = orderTableId;
-        this.orderLineItemCreates = orderLineItemCreates;
+        this.menuSnapShots = menuSnapShots;
     }
 
     public Long getOrderTableId() {
         return orderTableId;
     }
 
-    public List<OrderLineItemCreate> getOrderLineItemCreates() {
-        return orderLineItemCreates;
+    public List<MenuSnapShot> getMenuSnapShots() {
+        return menuSnapShots;
     }
 
-    public static class OrderLineItemCreate {
+    public static class MenuSnapShot {
 
         private final Long menuId;
+        private final String name;
+        private final BigDecimal price;
+        private final List<ProductSnapShot> productSnapShots;
         private final Long quantity;
 
-        public OrderLineItemCreate(final Long menuId, final Long quantity) {
+        public MenuSnapShot(final Long menuId, final String name, final BigDecimal price, List<ProductSnapShot> productSnapShots, final Long quantity) {
             this.menuId = menuId;
+            this.name = name;
+            this.price = price;
+            this.productSnapShots = productSnapShots;
             this.quantity = quantity;
         }
 
@@ -36,6 +43,54 @@ public final class OrderCreateRequest {
 
         public Long getQuantity() {
             return quantity;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public BigDecimal getPrice() {
+            return price;
+        }
+
+        public List<ProductSnapShot> getProductSnapShots() {
+            return productSnapShots;
+        }
+
+        public static class ProductSnapShot{
+            private final Long menuProductId;
+            private final Long productId;
+            private final String name;
+            private final BigDecimal price;
+            private final Long quantity;
+
+            public ProductSnapShot(final Long menuProductId, final Long productId, final String name, final BigDecimal price, final Long quantity) {
+                this.menuProductId = menuProductId;
+                this.productId = productId;
+                this.name = name;
+                this.price = price;
+                this.quantity = quantity;
+            }
+
+            public Long getMenuProductId() {
+                return menuProductId;
+            }
+
+            public Long getProductId() {
+                return productId;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public BigDecimal getPrice() {
+                return price;
+            }
+
+            public Long getQuantity() {
+                return quantity;
+            }
         }
     }
 }

--- a/src/main/java/kitchenpos/order/application/dto/OrderResponse.java
+++ b/src/main/java/kitchenpos/order/application/dto/OrderResponse.java
@@ -20,7 +20,7 @@ public final class OrderResponse {
                 .stream()
                 .map(OrderLineItem::getSeq)
                 .collect(Collectors.toList());
-        return new OrderResponse(order.getId(), order.getOrderTable().getId(), order.getOrderStatus(), order.getOrderedTime(), orderLineItemIds);
+        return new OrderResponse(order.getId(), order.getOrderTableId(), order.getOrderStatus(), order.getOrderedTime(), orderLineItemIds);
     }
 
     private OrderResponse(final Long id, final Long orderTableId, final String orderStatus, final LocalDateTime orderedTime, final List<Long> orderLineItemIds) {

--- a/src/main/java/kitchenpos/order/domain/Order.java
+++ b/src/main/java/kitchenpos/order/domain/Order.java
@@ -1,7 +1,5 @@
 package kitchenpos.order.domain;
 
-import kitchenpos.table.domain.OrderTable;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -10,7 +8,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
@@ -25,9 +22,8 @@ public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
-    @JoinColumn(name = "order_table_id", nullable = false)
-    private OrderTable orderTable;
+    @Column(name = "order_table_id", nullable = false)
+    private Long orderTableId;
     @Column(nullable = false)
     private String orderStatus;
     @Column(nullable = false)
@@ -39,26 +35,19 @@ public class Order {
     public Order() {
     }
 
-    public Order(final OrderTable orderTable, final String orderStatus, final LocalDateTime orderedTime, final List<OrderLineItem> orderLineItems) {
-        validateOrderTable(orderTable);
-        this.orderTable = orderTable;
+    public Order(final Long orderTableId, final String orderStatus, final LocalDateTime orderedTime, final List<OrderLineItem> orderLineItems) {
+        this.orderTableId = orderTableId;
         this.orderStatus = orderStatus;
         this.orderedTime = orderedTime;
         this.orderLineItems = orderLineItems;
-    }
-
-    private void validateOrderTable(final OrderTable orderTable) {
-        if (orderTable.isEmpty()) {
-            throw new IllegalArgumentException();
-        }
     }
 
     public Long getId() {
         return id;
     }
 
-    public OrderTable getOrderTable() {
-        return orderTable;
+    public Long getOrderTableId() {
+        return orderTableId;
     }
 
     public String getOrderStatus() {

--- a/src/main/java/kitchenpos/order/domain/Order.java
+++ b/src/main/java/kitchenpos/order/domain/Order.java
@@ -2,6 +2,7 @@ package kitchenpos.order.domain;
 
 import kitchenpos.table.domain.OrderTable;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -31,7 +32,8 @@ public class Order {
     private String orderStatus;
     @Column(nullable = false)
     private LocalDateTime orderedTime;
-    @OneToMany(mappedBy = "order", fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "order_id", nullable = false)
     private List<OrderLineItem> orderLineItems;
 
     public Order() {
@@ -71,12 +73,7 @@ public class Order {
         return orderLineItems;
     }
 
-    public void setOrderStatus(String name) {
-        this.orderStatus = name;
-    }
-
     public void addOrderLineItem(final OrderLineItem orderLineItem) {
-        orderLineItem.settingOrder(this);
         final List<OrderLineItem> items = new ArrayList<>(orderLineItems);
         items.add(orderLineItem);
         orderLineItems = items;

--- a/src/main/java/kitchenpos/order/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItem.java
@@ -1,14 +1,10 @@
 package kitchenpos.order.domain;
 
-import kitchenpos.menu.domain.Menu;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 
 @Entity
 public class OrderLineItem {
@@ -16,21 +12,16 @@ public class OrderLineItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long seq;
-    @ManyToOne
-    @JoinColumn(name = "order_id", nullable = false)
-    private Order order;
-    @ManyToOne
-    @JoinColumn(name = "menu_id", nullable = false)
-    private Menu menu;
+    @Column(name = "menu_id", nullable = false)
+    private Long menuId;
     @Column(nullable = false)
     private long quantity;
 
     public OrderLineItem() {
     }
 
-    public OrderLineItem(final Order order, final Menu menu, final long quantity) {
-        this.order = order;
-        this.menu = menu;
+    public OrderLineItem(final Long menuId, final Long quantity) {
+        this.menuId = menuId;
         this.quantity = quantity;
     }
 
@@ -38,19 +29,11 @@ public class OrderLineItem {
         return seq;
     }
 
-    public Order getOrder() {
-        return order;
-    }
-
-    public Menu getMenu() {
-        return menu;
+    public Long getMenuId() {
+        return menuId;
     }
 
     public long getQuantity() {
         return quantity;
-    }
-
-    public void settingOrder(final Order savedOrder) {
-        this.order = savedOrder;
     }
 }

--- a/src/main/java/kitchenpos/order/domain/OrderLineItem.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItem.java
@@ -1,10 +1,14 @@
 package kitchenpos.order.domain;
 
+import kitchenpos.menu.domain.vo.Price;
+
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import java.math.BigDecimal;
 
 @Entity
 public class OrderLineItem {
@@ -15,13 +19,19 @@ public class OrderLineItem {
     @Column(name = "menu_id", nullable = false)
     private Long menuId;
     @Column(nullable = false)
+    private String menuName;
+    @Embedded
+    private Price menuPrice;
+    @Column(nullable = false)
     private long quantity;
 
     public OrderLineItem() {
     }
 
-    public OrderLineItem(final Long menuId, final Long quantity) {
+    public OrderLineItem(final Long menuId, final String menuName, final BigDecimal menuPrice, final Long quantity) {
         this.menuId = menuId;
+        this.menuName = menuName;
+        this.menuPrice = new Price(menuPrice);
         this.quantity = quantity;
     }
 
@@ -31,6 +41,14 @@ public class OrderLineItem {
 
     public Long getMenuId() {
         return menuId;
+    }
+
+    public String getMenuName() {
+        return menuName;
+    }
+
+    public Price getMenuPrice() {
+        return menuPrice;
     }
 
     public long getQuantity() {

--- a/src/main/java/kitchenpos/order/domain/OrderLineItemRepository.java
+++ b/src/main/java/kitchenpos/order/domain/OrderLineItemRepository.java
@@ -2,8 +2,5 @@ package kitchenpos.order.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface OrderLineItemRepository extends JpaRepository<OrderLineItem, Long> {
-    List<OrderLineItem> findAllByOrder(final Order order);
 }

--- a/src/main/java/kitchenpos/order/domain/OrderRepository.java
+++ b/src/main/java/kitchenpos/order/domain/OrderRepository.java
@@ -1,12 +1,11 @@
 package kitchenpos.order.domain;
 
-import kitchenpos.table.domain.OrderTable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
-    boolean existsByOrderTableAndOrderStatusIn(final OrderTable orderTable, final List<String> list);
+    boolean existsByOrderTableIdAndOrderStatusIn(final Long orderTableId, final List<String> list);
 
-    boolean existsByOrderTableInAndOrderStatusIn(final List<OrderTable> orderTables, final List<String> status);
+    boolean existsByOrderTableIdInAndOrderStatusIn(final List<Long> orderTableIds, final List<String> status);
 }

--- a/src/main/java/kitchenpos/table/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/table/application/TableGroupService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class TableGroupService {
@@ -46,8 +47,9 @@ public class TableGroupService {
                 .orElseThrow(IllegalArgumentException::new);
 
         final List<OrderTable> orderTables = tableGroup.getOrderTables();
-        if (orderRepository.existsByOrderTableInAndOrderStatusIn(
-                orderTables, Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
+        final List<Long> orderTableIds = orderTables.stream().map(OrderTable::getId).collect(Collectors.toList());
+        if (orderRepository.existsByOrderTableIdInAndOrderStatusIn(
+                orderTableIds, Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
             throw new IllegalArgumentException();
         }
 

--- a/src/main/java/kitchenpos/table/application/TableService.java
+++ b/src/main/java/kitchenpos/table/application/TableService.java
@@ -3,7 +3,7 @@ package kitchenpos.table.application;
 import kitchenpos.table.application.dto.OrderTableCreateRequest;
 import kitchenpos.table.application.dto.OrderTableResponse;
 import kitchenpos.table.domain.OrderTable;
-import kitchenpos.table.domain.OrderTableChangeEmptyValidateOrderStatusEvent;
+import kitchenpos.table.domain.OrderTableEvent;
 import kitchenpos.table.domain.OrderTableRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -49,7 +49,7 @@ public class TableService {
             throw new IllegalArgumentException();
         }
 
-        applicationEventPublisher.publishEvent(new OrderTableChangeEmptyValidateOrderStatusEvent(savedOrderTable.getId()));
+        applicationEventPublisher.publishEvent(new OrderTableEvent(savedOrderTable.getId()));
 
         savedOrderTable.changeEmpty(empty);
 

--- a/src/main/java/kitchenpos/table/application/TableService.java
+++ b/src/main/java/kitchenpos/table/application/TableService.java
@@ -12,7 +12,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 @Service
 public class TableService {
@@ -51,8 +50,8 @@ public class TableService {
             throw new IllegalArgumentException();
         }
 
-        if (orderRepository.existsByOrderTableAndOrderStatusIn(
-                savedOrderTable, Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
+        if (orderRepository.existsByOrderTableIdAndOrderStatusIn(
+                savedOrderTable.getId(), Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
             throw new IllegalArgumentException();
         }
 

--- a/src/main/java/kitchenpos/table/application/TableService.java
+++ b/src/main/java/kitchenpos/table/application/TableService.java
@@ -1,26 +1,25 @@
 package kitchenpos.table.application;
 
-import kitchenpos.order.domain.OrderRepository;
-import kitchenpos.order.domain.OrderStatus;
 import kitchenpos.table.application.dto.OrderTableCreateRequest;
 import kitchenpos.table.application.dto.OrderTableResponse;
 import kitchenpos.table.domain.OrderTable;
+import kitchenpos.table.domain.OrderTableChangeEmptyValidateOrderStatusEvent;
 import kitchenpos.table.domain.OrderTableRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Service
 public class TableService {
-    private final OrderRepository orderRepository;
     private final OrderTableRepository orderTableRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
-    public TableService(final OrderRepository orderRepository, final OrderTableRepository orderTableRepository) {
-        this.orderRepository = orderRepository;
+    public TableService(final OrderTableRepository orderTableRepository, final ApplicationEventPublisher applicationEventPublisher) {
         this.orderTableRepository = orderTableRepository;
+        this.applicationEventPublisher = applicationEventPublisher;
     }
 
     @Transactional
@@ -50,10 +49,7 @@ public class TableService {
             throw new IllegalArgumentException();
         }
 
-        if (orderRepository.existsByOrderTableIdAndOrderStatusIn(
-                savedOrderTable.getId(), Arrays.asList(OrderStatus.COOKING.name(), OrderStatus.MEAL.name()))) {
-            throw new IllegalArgumentException();
-        }
+        applicationEventPublisher.publishEvent(new OrderTableChangeEmptyValidateOrderStatusEvent(savedOrderTable.getId()));
 
         savedOrderTable.changeEmpty(empty);
 

--- a/src/main/java/kitchenpos/table/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/table/domain/OrderTable.java
@@ -59,7 +59,7 @@ public class OrderTable {
     }
 
     public boolean isGroupable() {
-        return this.isEmpty() && Objects.isNull(this.tableGroupId);
+        return this.isEmpty() && isTableGroupNull();
     }
 
     public boolean isTableGroupNull() {

--- a/src/main/java/kitchenpos/table/domain/OrderTable.java
+++ b/src/main/java/kitchenpos/table/domain/OrderTable.java
@@ -5,8 +5,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import java.util.Objects;
 
 @Entity
@@ -15,9 +13,8 @@ public class OrderTable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne
-    @JoinColumn(name = "table_group_id")
-    private TableGroup tableGroup;
+    @Column(name = "table_group_id")
+    private Long tableGroupId;
     @Column(nullable = false)
     private int numberOfGuests;
     @Column(nullable = false)
@@ -26,8 +23,8 @@ public class OrderTable {
     public OrderTable() {
     }
 
-    public OrderTable(final TableGroup tableGroup, final int numberOfGuests, final boolean empty) {
-        this.tableGroup = tableGroup;
+    public OrderTable(final Long tableGroupId, final int numberOfGuests, final boolean empty) {
+        this.tableGroupId = tableGroupId;
         this.numberOfGuests = numberOfGuests;
         this.empty = empty;
     }
@@ -40,16 +37,9 @@ public class OrderTable {
         return id;
     }
 
-    public TableGroup getTableGroup() {
-        return tableGroup;
-    }
 
     public Long getTableGroupId() {
-        if (Objects.isNull(tableGroup)) {
-            return null;
-        }
-
-        return tableGroup.getId();
+        return tableGroupId;
     }
 
     public int getNumberOfGuests() {
@@ -60,8 +50,8 @@ public class OrderTable {
         return empty;
     }
 
-    public void settingTableGroup(final TableGroup savedTableGroup) {
-        this.tableGroup = savedTableGroup;
+    public void joinTableGroupById(final Long tableGroupId) {
+        this.tableGroupId = tableGroupId;
     }
 
     public void changeEmpty(final boolean empty) {
@@ -69,11 +59,11 @@ public class OrderTable {
     }
 
     public boolean isGroupable() {
-        return this.isEmpty() && Objects.isNull(this.tableGroup);
+        return this.isEmpty() && Objects.isNull(this.tableGroupId);
     }
 
     public boolean isTableGroupNull() {
-        return Objects.isNull(this.tableGroup);
+        return Objects.isNull(this.tableGroupId);
     }
 
     public void changeNumberOfGuests(final int numberOfGuests) {

--- a/src/main/java/kitchenpos/table/domain/OrderTableChangeEmptyValidateOrderStatusEvent.java
+++ b/src/main/java/kitchenpos/table/domain/OrderTableChangeEmptyValidateOrderStatusEvent.java
@@ -1,0 +1,14 @@
+package kitchenpos.table.domain;
+
+public final class OrderTableChangeEmptyValidateOrderStatusEvent {
+
+    private final Long orderTableId;
+
+    public OrderTableChangeEmptyValidateOrderStatusEvent(final Long orderTableId) {
+        this.orderTableId = orderTableId;
+    }
+
+    public Long getOrderTableId() {
+        return orderTableId;
+    }
+}

--- a/src/main/java/kitchenpos/table/domain/OrderTableEvent.java
+++ b/src/main/java/kitchenpos/table/domain/OrderTableEvent.java
@@ -1,10 +1,10 @@
 package kitchenpos.table.domain;
 
-public final class OrderTableChangeEmptyValidateOrderStatusEvent {
+public final class OrderTableEvent {
 
     private final Long orderTableId;
 
-    public OrderTableChangeEmptyValidateOrderStatusEvent(final Long orderTableId) {
+    public OrderTableEvent(final Long orderTableId) {
         this.orderTableId = orderTableId;
     }
 

--- a/src/main/java/kitchenpos/table/domain/OrderTableRepository.java
+++ b/src/main/java/kitchenpos/table/domain/OrderTableRepository.java
@@ -5,7 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface OrderTableRepository extends JpaRepository<OrderTable, Long> {
-    List<OrderTable> findAllByTableGroup(final TableGroup tableGroup);
-
     List<OrderTable> findAllByIdIn(final List<Long> orderTableIds);
 }

--- a/src/main/java/kitchenpos/table/domain/TableGroup.java
+++ b/src/main/java/kitchenpos/table/domain/TableGroup.java
@@ -2,11 +2,13 @@ package kitchenpos.table.domain;
 
 import org.springframework.util.CollectionUtils;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,7 +22,8 @@ public class TableGroup {
     private Long id;
     @Column(nullable = false)
     private LocalDateTime createdDate;
-    @OneToMany(mappedBy = "tableGroup")
+    @OneToMany(cascade = CascadeType.REFRESH)
+    @JoinColumn(name = "table_group_id")
     private List<OrderTable> orderTables = new ArrayList<>();
 
     public TableGroup() {
@@ -29,7 +32,7 @@ public class TableGroup {
     public TableGroup(final LocalDateTime createdDate, final List<OrderTable> orderTables) {
         validate(orderTables);
         for (final OrderTable savedOrderTable : orderTables) {
-            savedOrderTable.settingTableGroup(this);
+            savedOrderTable.joinTableGroupById(this.id);
             savedOrderTable.changeEmpty(false);
         }
         this.createdDate = createdDate;
@@ -61,7 +64,7 @@ public class TableGroup {
 
     public void unGroup() {
         for (final OrderTable orderTable : orderTables) {
-            orderTable.settingTableGroup(null);
+            orderTable.joinTableGroupById(null);
             orderTable.changeEmpty(false);
         }
     }

--- a/src/main/java/kitchenpos/tablegroup/application/TableGroupService.java
+++ b/src/main/java/kitchenpos/tablegroup/application/TableGroupService.java
@@ -1,12 +1,12 @@
-package kitchenpos.table.application;
+package kitchenpos.tablegroup.application;
 
 import kitchenpos.order.domain.OrderRepository;
 import kitchenpos.order.domain.OrderStatus;
-import kitchenpos.table.application.dto.TableGroupCreateRequest;
+import kitchenpos.tablegroup.application.dto.TableGroupCreateRequest;
 import kitchenpos.table.domain.OrderTable;
 import kitchenpos.table.domain.OrderTableRepository;
-import kitchenpos.table.domain.TableGroup;
-import kitchenpos.table.domain.TableGroupRepository;
+import kitchenpos.tablegroup.domain.TableGroup;
+import kitchenpos.tablegroup.domain.TableGroupRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/kitchenpos/tablegroup/application/dto/TableGroupCreateRequest.java
+++ b/src/main/java/kitchenpos/tablegroup/application/dto/TableGroupCreateRequest.java
@@ -1,4 +1,4 @@
-package kitchenpos.table.application.dto;
+package kitchenpos.tablegroup.application.dto;
 
 import java.util.List;
 

--- a/src/main/java/kitchenpos/tablegroup/domain/TableGroup.java
+++ b/src/main/java/kitchenpos/tablegroup/domain/TableGroup.java
@@ -1,5 +1,6 @@
-package kitchenpos.table.domain;
+package kitchenpos.tablegroup.domain;
 
+import kitchenpos.table.domain.OrderTable;
 import org.springframework.util.CollectionUtils;
 
 import javax.persistence.CascadeType;

--- a/src/main/java/kitchenpos/tablegroup/domain/TableGroupRepository.java
+++ b/src/main/java/kitchenpos/tablegroup/domain/TableGroupRepository.java
@@ -1,4 +1,4 @@
-package kitchenpos.table.domain;
+package kitchenpos.tablegroup.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/kitchenpos/tablegroup/ui/TableGroupRestController.java
+++ b/src/main/java/kitchenpos/tablegroup/ui/TableGroupRestController.java
@@ -1,8 +1,8 @@
-package kitchenpos.table.ui;
+package kitchenpos.tablegroup.ui;
 
-import kitchenpos.table.application.TableGroupService;
-import kitchenpos.table.application.dto.TableGroupCreateRequest;
-import kitchenpos.table.domain.TableGroup;
+import kitchenpos.tablegroup.application.TableGroupService;
+import kitchenpos.tablegroup.application.dto.TableGroupCreateRequest;
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/resources/db/migration/V1__Initialize_project_tables.sql
+++ b/src/main/resources/db/migration/V1__Initialize_project_tables.sql
@@ -25,10 +25,12 @@ create table menu_product
 
 create table order_line_item
 (
-    seq      bigint not null auto_increment,
-    quantity bigint not null,
-    menu_id  bigint not null,
-    order_id bigint not null,
+    seq       bigint         not null auto_increment,
+    menu_name varchar(255)   not null,
+    price     decimal(19, 2) not null,
+    quantity  bigint         not null,
+    menu_id   bigint         not null,
+    order_id  bigint         not null,
     primary key (seq)
 );
 

--- a/src/test/java/kitchenpos/EntitySupporter.java
+++ b/src/test/java/kitchenpos/EntitySupporter.java
@@ -7,7 +7,7 @@ import kitchenpos.order.domain.OrderLineItemRepository;
 import kitchenpos.order.domain.OrderRepository;
 import kitchenpos.product.domain.ProductRepository;
 import kitchenpos.table.domain.OrderTableRepository;
-import kitchenpos.table.domain.TableGroupRepository;
+import kitchenpos.tablegroup.domain.TableGroupRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/src/test/java/kitchenpos/TestFixtureBuilder.java
+++ b/src/test/java/kitchenpos/TestFixtureBuilder.java
@@ -7,7 +7,7 @@ import kitchenpos.order.domain.Order;
 import kitchenpos.order.domain.OrderLineItem;
 import kitchenpos.product.domain.Product;
 import kitchenpos.table.domain.OrderTable;
-import kitchenpos.table.domain.TableGroup;
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -38,7 +38,7 @@ class MenuServiceTest extends ServiceTest {
         product = new Product("product", new BigDecimal(PRODUCT_PRICE));
         product = testFixtureBuilder.buildProduct(product);
 
-        menuProduct = new MenuProduct(product.getId(), 1);
+        menuProduct = new MenuProduct(product, 1);
     }
 
     @DisplayName("메뉴 생성 테스트")

--- a/src/test/java/kitchenpos/application/MenuServiceTest.java
+++ b/src/test/java/kitchenpos/application/MenuServiceTest.java
@@ -38,7 +38,7 @@ class MenuServiceTest extends ServiceTest {
         product = new Product("product", new BigDecimal(PRODUCT_PRICE));
         product = testFixtureBuilder.buildProduct(product);
 
-        menuProduct = new MenuProduct(null, product, 1);
+        menuProduct = new MenuProduct(product.getId(), 1);
     }
 
     @DisplayName("메뉴 생성 테스트")

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -123,7 +123,7 @@ class OrderServiceTest extends ServiceTest {
         @Test
         void orderFindAll() {
             //given
-            Order order = new Order(orderTable, OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
+            Order order = new Order(orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
             order = testFixtureBuilder.buildOrder(order);
 
             //when
@@ -146,7 +146,7 @@ class OrderServiceTest extends ServiceTest {
         @Test
         void orderStatusChange() {
             //given
-            Order order = new Order(orderTable, OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
+            Order order = new Order(orderTable.getId(), OrderStatus.COOKING.name(), LocalDateTime.now(), Collections.emptyList());
             order = testFixtureBuilder.buildOrder(order);
 
             //when
@@ -174,7 +174,7 @@ class OrderServiceTest extends ServiceTest {
         @Test
         void orderStatusChangeFailWhenStatusIsCompletion() {
             //given
-            Order completionOrder = new Order(orderTable, OrderStatus.COMPLETION.name(), LocalDateTime.now(), Collections.emptyList());
+            Order completionOrder = new Order(orderTable.getId(), OrderStatus.COMPLETION.name(), LocalDateTime.now(), Collections.emptyList());
             completionOrder = testFixtureBuilder.buildOrder(completionOrder);
 
             final String changeStatus = OrderStatus.MEAL.name();

--- a/src/test/java/kitchenpos/application/OrderServiceTest.java
+++ b/src/test/java/kitchenpos/application/OrderServiceTest.java
@@ -39,9 +39,9 @@ class OrderServiceTest extends ServiceTest {
         menuGroup = testFixtureBuilder.buildMenuGroup(menuGroup);
 
         menus = new ArrayList<>();
-        Menu menu1 = new Menu("name", new BigDecimal(100), menuGroup.getId(), Collections.emptyList());
+        Menu menu1 = new Menu("name", new BigDecimal(0), menuGroup.getId(), Collections.emptyList());
         menus.add(testFixtureBuilder.buildMenu(menu1));
-        Menu menu2 = new Menu("name", new BigDecimal(100), menuGroup.getId(), Collections.emptyList());
+        Menu menu2 = new Menu("name", new BigDecimal(0), menuGroup.getId(), Collections.emptyList());
         menus.add(testFixtureBuilder.buildMenu(menu2));
 
         orderTable = new OrderTable(null, 3, false);

--- a/src/test/java/kitchenpos/application/TableGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableGroupServiceTest.java
@@ -118,7 +118,7 @@ class TableGroupServiceTest extends ServiceTest {
             TableGroup beforeTableGroup = new TableGroup(LocalDateTime.now(), orderTables);
             beforeTableGroup = testFixtureBuilder.buildTableGroup(beforeTableGroup);
 
-            OrderTable tableGroupIdNotNullOrderTable = new OrderTable(beforeTableGroup, 3, true);
+            OrderTable tableGroupIdNotNullOrderTable = new OrderTable(beforeTableGroup.getId(), 3, true);
             tableGroupIdNotNullOrderTable = testFixtureBuilder.buildOrderTable(tableGroupIdNotNullOrderTable);
 
             orderTables.add(tableGroupIdNotNullOrderTable);
@@ -154,7 +154,7 @@ class TableGroupServiceTest extends ServiceTest {
             TableGroup tableGroup = new TableGroup(LocalDateTime.now(), orderTables);
             tableGroup = testFixtureBuilder.buildTableGroup(tableGroup);
 
-            OrderTable notCompletionOrdertable = new OrderTable(tableGroup, 3, false);
+            OrderTable notCompletionOrdertable = new OrderTable(tableGroup.getId(), 3, false);
             notCompletionOrdertable = testFixtureBuilder.buildOrderTable(notCompletionOrdertable);
 
             final Order notCompletionOrder = new Order(notCompletionOrdertable, orderStatus, LocalDateTime.now(), Collections.emptyList());

--- a/src/test/java/kitchenpos/application/TableGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableGroupServiceTest.java
@@ -2,10 +2,10 @@ package kitchenpos.application;
 
 import kitchenpos.ServiceTest;
 import kitchenpos.order.domain.Order;
-import kitchenpos.table.application.TableGroupService;
-import kitchenpos.table.application.dto.TableGroupCreateRequest;
+import kitchenpos.tablegroup.application.TableGroupService;
+import kitchenpos.tablegroup.application.dto.TableGroupCreateRequest;
 import kitchenpos.table.domain.OrderTable;
-import kitchenpos.table.domain.TableGroup;
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/kitchenpos/application/TableGroupServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableGroupServiceTest.java
@@ -154,10 +154,10 @@ class TableGroupServiceTest extends ServiceTest {
             TableGroup tableGroup = new TableGroup(LocalDateTime.now(), orderTables);
             tableGroup = testFixtureBuilder.buildTableGroup(tableGroup);
 
-            OrderTable notCompletionOrdertable = new OrderTable(tableGroup.getId(), 3, false);
-            notCompletionOrdertable = testFixtureBuilder.buildOrderTable(notCompletionOrdertable);
+            OrderTable orderTable = new OrderTable(tableGroup.getId(), 3, false);
+            orderTable = testFixtureBuilder.buildOrderTable(orderTable);
 
-            final Order notCompletionOrder = new Order(notCompletionOrdertable, orderStatus, LocalDateTime.now(), Collections.emptyList());
+            final Order notCompletionOrder = new Order(orderTable.getId(), orderStatus, LocalDateTime.now(), Collections.emptyList());
             testFixtureBuilder.buildOrder(notCompletionOrder);
 
             // when & then

--- a/src/test/java/kitchenpos/application/TableServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableServiceTest.java
@@ -132,18 +132,14 @@ class TableServiceTest extends ServiceTest {
             OrderTable notCompletionOrdertable = new OrderTable(null, 3, false);
             notCompletionOrdertable = testFixtureBuilder.buildOrderTable(notCompletionOrdertable);
 
-            final Order notCompletionOrder = new Order(notCompletionOrdertable, orderStatus, LocalDateTime.now(), Collections.emptyList());
+            final Order notCompletionOrder = new Order(notCompletionOrdertable.getId(), orderStatus, LocalDateTime.now(), Collections.emptyList());
             testFixtureBuilder.buildOrder(notCompletionOrder);
-
-            final OrderTable changingStatus = new OrderTable();
-            changingStatus.changeEmpty(!notCompletionOrdertable.isEmpty());
 
             // when & then
             final Long orderTableId = notCompletionOrdertable.getId();
             assertThatThrownBy(() -> tableService.changeEmpty(orderTableId, true))
                     .isInstanceOf(IllegalArgumentException.class);
         }
-
     }
 
     @DisplayName("주문 테이블 고객 수 변경")

--- a/src/test/java/kitchenpos/application/TableServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableServiceTest.java
@@ -6,7 +6,7 @@ import kitchenpos.table.application.TableService;
 import kitchenpos.table.application.dto.OrderTableCreateRequest;
 import kitchenpos.table.application.dto.OrderTableResponse;
 import kitchenpos.table.domain.OrderTable;
-import kitchenpos.table.domain.TableGroup;
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kitchenpos/application/TableServiceTest.java
+++ b/src/test/java/kitchenpos/application/TableServiceTest.java
@@ -117,7 +117,6 @@ class TableServiceTest extends ServiceTest {
             final List<OrderTable> orderTables = List.of(orderTable1, orderTable2);
             TableGroup tableGroup = new TableGroup(LocalDateTime.now(), orderTables);
             testFixtureBuilder.buildTableGroup(tableGroup);
-            orderTables.forEach(orderTable -> testFixtureBuilder.buildOrderTable(orderTable));
 
             // when & then
             final Long orderTableId = orderTable1.getId();

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -25,7 +25,8 @@ class MenuTest {
             final String menuName = "menu";
             final BigDecimal price = new BigDecimal(1000);
             final long menuGroupId = 1L;
-            final List<MenuProduct> menuProducts = Collections.emptyList();
+            final Product product = new Product("product", new BigDecimal(3000));
+            final List<MenuProduct> menuProducts = List.of(new MenuProduct(product, 4));
 
             //when
             final Menu menu = new Menu(menuName, price, menuGroupId, menuProducts);
@@ -66,32 +67,6 @@ class MenuTest {
             // when & then
             assertThatThrownBy(() -> new Menu(menuName, price, menuGroupId, menuProducts))
                     .isInstanceOf(IllegalArgumentException.class);
-        }
-    }
-
-    @DisplayName("메뉴 상품 엔티티 추가 테스트")
-    @Nested
-    class MenuProductAddTest {
-
-        @DisplayName("메뉴 상품 엔티티를 추가한다.")
-        @Test
-        void menuProductAddTest() {
-            //given
-            final String menuName = "menu";
-            final BigDecimal price = new BigDecimal(1000);
-            final long menuGroupId = 1L;
-            final List<MenuProduct> menuProducts = Collections.emptyList();
-            final Menu menu = new Menu(menuName, price, menuGroupId, menuProducts);
-
-            final Product product = new Product("name", new BigDecimal(100));
-            final MenuProduct menuProduct = new MenuProduct(product.getId(), 3);
-            //when
-            menu.addMenuProduct(menuProduct);
-
-            //then
-            assertSoftly(softly -> {
-                softly.assertThat(menu.getMenuProducts().size()).isEqualTo(1);
-            });
         }
     }
 }

--- a/src/test/java/kitchenpos/menu/domain/MenuTest.java
+++ b/src/test/java/kitchenpos/menu/domain/MenuTest.java
@@ -84,13 +84,12 @@ class MenuTest {
             final Menu menu = new Menu(menuName, price, menuGroupId, menuProducts);
 
             final Product product = new Product("name", new BigDecimal(100));
-            final MenuProduct menuProduct = new MenuProduct(null, product, 3);
+            final MenuProduct menuProduct = new MenuProduct(product.getId(), 3);
             //when
             menu.addMenuProduct(menuProduct);
 
             //then
             assertSoftly(softly -> {
-                softly.assertThat(menuProduct.getMenu()).isEqualTo(menu);
                 softly.assertThat(menu.getMenuProducts().size()).isEqualTo(1);
             });
         }

--- a/src/test/java/kitchenpos/order/domain/OrderTest.java
+++ b/src/test/java/kitchenpos/order/domain/OrderTest.java
@@ -1,6 +1,5 @@
 package kitchenpos.order.domain;
 
-import kitchenpos.table.domain.OrderTable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,29 +19,14 @@ class OrderTest {
         @DisplayName("주문을 생성한다.")
         @Test
         void orderCreateTest() {
-            //given
-            final OrderTable orderTable = new OrderTable(null, 1, false);
-
-            //when
-            final Order order = new Order(orderTable, OrderStatus.MEAL.name(), LocalDateTime.now(), Collections.emptyList());
+            //given & when
+            final Order order = new Order(null, OrderStatus.MEAL.name(), LocalDateTime.now(), Collections.emptyList());
 
             //then
             assertSoftly(softly -> {
                 softly.assertThat(order.getId()).isNull();
-                softly.assertThat(order.getOrderTable()).isEqualTo(orderTable);
                 softly.assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.MEAL.name());
             });
-        }
-
-        @DisplayName("주문 테이블이 비어있으면 실패한다.")
-        @Test
-        void orderCreateFailWhenOrderTableIsEmpty() {
-            //given
-            final OrderTable orderTable = new OrderTable(null, 1, true);
-
-            // when & then
-            assertThatThrownBy(() -> new Order(orderTable, OrderStatus.MEAL.name(), LocalDateTime.now(), Collections.emptyList()))
-                    .isInstanceOf(IllegalArgumentException.class);
         }
     }
 
@@ -54,8 +38,7 @@ class OrderTest {
         @Test
         void orderStatusChangeTest() {
             //given
-            final OrderTable orderTable = new OrderTable(null, 1, false);
-            final Order order = new Order(orderTable, OrderStatus.MEAL.name(), LocalDateTime.now(), Collections.emptyList());
+            final Order order = new Order(null, OrderStatus.MEAL.name(), LocalDateTime.now(), Collections.emptyList());
             final String afterStatus = OrderStatus.COMPLETION.name();
 
             //when
@@ -71,8 +54,7 @@ class OrderTest {
         @Test
         void orderStatusChangeFailWhenOrderStatusCompletion() {
             //given
-            final OrderTable orderTable = new OrderTable(null, 1, false);
-            final Order order = new Order(orderTable, OrderStatus.COMPLETION.name(), LocalDateTime.now(), Collections.emptyList());
+            final Order order = new Order(null, OrderStatus.COMPLETION.name(), LocalDateTime.now(), Collections.emptyList());
 
             // when & then
             assertThatThrownBy(() -> order.changeOrderStatus(OrderStatus.MEAL.name()))

--- a/src/test/java/kitchenpos/table/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/table/domain/OrderTableTest.java
@@ -49,12 +49,12 @@ class OrderTableTest {
             final OrderTable orderTable = new OrderTable(null, guests, empty);
 
             //when
-            orderTable.settingTableGroup(afterTableGroup);
+            orderTable.joinTableGroupById(afterTableGroup.getId());
 
             //then
             assertSoftly(softly -> {
                 softly.assertThat(orderTable.getId()).isNull();
-                softly.assertThat(orderTable.getTableGroup()).isEqualTo(afterTableGroup);
+                softly.assertThat(orderTable.getTableGroupId()).isEqualTo(afterTableGroup.getId());
                 softly.assertThat(orderTable.getNumberOfGuests()).isEqualTo(guests);
                 softly.assertThat(orderTable.isEmpty()).isEqualTo(empty);
             });

--- a/src/test/java/kitchenpos/table/domain/OrderTableTest.java
+++ b/src/test/java/kitchenpos/table/domain/OrderTableTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.table.domain;
 
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/kitchenpos/table/domain/TableGroupTest.java
+++ b/src/test/java/kitchenpos/table/domain/TableGroupTest.java
@@ -71,8 +71,8 @@ class TableGroupTest {
 
             //then
             assertSoftly(softly -> {
-                softly.assertThat(tableGroup.getOrderTables().get(0).getTableGroup()).isNull();
-                softly.assertThat(tableGroup.getOrderTables().get(1).getTableGroup()).isNull();
+                softly.assertThat(tableGroup.getOrderTables().get(0).getTableGroupId()).isNull();
+                softly.assertThat(tableGroup.getOrderTables().get(1).getTableGroupId()).isNull();
             });
         }
     }

--- a/src/test/java/kitchenpos/table/domain/TableGroupTest.java
+++ b/src/test/java/kitchenpos/table/domain/TableGroupTest.java
@@ -1,5 +1,6 @@
 package kitchenpos.table.domain;
 
+import kitchenpos.tablegroup.domain.TableGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
솔직히 이번 단계에서 요구사항을 충족했는지 자신은 없지만 일단 한 내용은 다음과 같습니다.

1. 패키지 양방향 참조 제거
<img width="213" alt="스크린샷 2023-10-25 오후 4 48 45" src="https://github.com/woowacourse/jwp-refactoring/assets/86831441/484f4048-8710-41ea-8ad3-2085d164d028">
<img width="242" alt="스크린샷 2023-10-25 오후 4 48 55" src="https://github.com/woowacourse/jwp-refactoring/assets/86831441/2960f7e8-bd96-4bbc-af3a-1e5601a1bd50">

왼쪽을 보면 table-order간 패키지 순환 참조가 있었는데, 이벤트 사용, 패키지 분리를 통해 순환 참조를 제거했습니다.

2. 도메인 객체가 아닌 id로 참조하도록 변경
기존에는 객체에서 집적참조를 이용했는데 최대한 Id값을 이용해 참조하도록 변경했습니다.
 
3. 같이 생성되는 경우 Casacade Persist 옵션 적용
Menu, Order에서 각각 MenuProduct와 OrderLineItems는 CascadeType.PERSIST를 사용했습니다.

4. 도메인 양방향 참조 제거
<img width="1196" alt="스크린샷 2023-10-24 오후 2 35 07" src="https://github.com/woowacourse/jwp-refactoring/assets/86831441/46dfcaa9-2c7c-4ab6-969e-2bcd8f5dddd7">
기존에는 Order-OrderLineItem, Menu-MenuProduct, OrderTable-TableGroup에서 양방향으로 참조하는 것에서
<img width="919" alt="스크린샷 2023-10-24 오후 4 13 47" src="https://github.com/woowacourse/jwp-refactoring/assets/86831441/3e993020-bcb5-4a08-90a0-9dda8e87bf61">
모두 단방향으로 변경하였습니다.   


5. 주문 후 주문 시 정보와 주문 처리 중 정보가 같은 경우에 주문이 생성되도록 구현했습니다.
dto에서 정보를 스냅샷 형태로 가져온 다음 static validator를 이용해 비교합니다.
비교 로직이 equals를 남발하는 형태인데, 구현의 어려움과 라이브러리 사용을 하지 않고 하려다보니 조금 무식한 형태로 구현한 것 같습니다.

리뷰 잘부탁드립니다. 감사합니다.
